### PR TITLE
Clean up Cargo for publishing to crates-io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,25 +12,25 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/fiberplane/fiberplane-rs"
+repository = "https://github.com/fiberplane/fiberplane"
 rust-version = "1.64"
 
 [workspace.dependencies]
-base64uuid = { version = "1.0.0-alpha.2", path = "base64uuid", default-features = false }
+base64uuid = { version = "1.0.0-alpha.3", path = "base64uuid", default-features = false }
 bytes = { version = "1", features = ["serde"] }
 fp-bindgen = { version = "3.0.0-alpha.1" }
 fp-bindgen-support = { version = "3.0.0-alpha.1" }
-fiberplane = { version = "1.0.0-alpha.2", path = "fiberplane" }
-fiberplane-api-client = { version = "1.0.0-alpha.2", path = "fiberplane-api-client" }
-fiberplane-markdown = { version = "1.0.0-alpha.2", path = "fiberplane-markdown" }
-fiberplane-models = { version = "1.0.0-alpha.2", path = "fiberplane-models" }
+fiberplane = { version = "1.0.0-alpha.3", path = "fiberplane" }
+fiberplane-api-client = { version = "1.0.0-alpha.3", path = "fiberplane-api-client" }
+fiberplane-markdown = { version = "1.0.0-alpha.3", path = "fiberplane-markdown" }
+fiberplane-models = { version = "1.0.0-alpha.3", path = "fiberplane-models" }
 fiberplane-provider-bindings = { version = "2.0.0-alpha.1", path = "fiberplane-provider-protocol/fiberplane-provider-bindings" }
 fiberplane-provider-runtime = { version = "2.0.0-alpha.1", path = "fiberplane-provider-protocol/fiberplane-provider-runtime" }
-fiberplane-templates = { version = "1.0.0-alpha.2", path = "fiberplane-templates" }
+fiberplane-templates = { version = "1.0.0-alpha.3", path = "fiberplane-templates" }
 once_cell = { version = "1.8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -48,9 +48,3 @@ vergen = { version = "7.4.2", default-features = false, features = [
     "build",
     "git",
 ] }
-
-[patch.crates-io]
-#fp-bindgen = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "main" }
-#fp-bindgen-support = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "main" }
-#fp-bindgen = { path = "../fp-bindgen/fp-bindgen" }
-#fp-bindgen-support = { path = "../fp-bindgen/fp-bindgen-support" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ repository = "https://github.com/fiberplane/fiberplane"
 rust-version = "1.64"
 
 [workspace.dependencies]
-base64uuid = { version = "1.0.0-alpha.3", path = "base64uuid", default-features = false }
+base64uuid = { version = "1.0.0", path = "base64uuid", default-features = false }
 bytes = { version = "1", features = ["serde"] }
 fp-bindgen = { version = "3.0.0-alpha.1" }
 fp-bindgen-support = { version = "3.0.0-alpha.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,9 @@ vergen = { version = "7.4.2", default-features = false, features = [
     "build",
     "git",
 ] }
+
+[patch.crates-io]
+#fp-bindgen = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "main" }
+#fp-bindgen-support = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "main" }
+#fp-bindgen = { path = "../fp-bindgen/fp-bindgen" }
+#fp-bindgen-support = { path = "../fp-bindgen/fp-bindgen-support" }

--- a/base64uuid/Cargo.toml
+++ b/base64uuid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base64uuid"
 description = "Type for representing base64url-encoded UUIDs"
-version = "1.0.0-alpha.2"
+version = "1.0.0"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/fiberplane-models/Cargo.toml
+++ b/fiberplane-models/Cargo.toml
@@ -19,7 +19,7 @@ fp-bindgen = ["base64uuid/fp-bindgen", "dep:fp-bindgen"]
 base64 = "0.13"
 base64uuid = { workspace = true, default-features = false }
 bytes = { workspace = true }
-clap = { version = "*", default-features = false, optional = true, features = [
+clap = { version = "4.1", default-features = false, optional = true, features = [
     "derive",
     "std",
 ] }


### PR DESCRIPTION
# Description

- Fix the link to the repository
- Remove the wildcard dependency to fiberplane-models
- Remove the local-dev patch

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] ~~The changes have been tested to be backwards compatible.~~
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] ~~PR for API is ready and reviewed: (please link)~~
- [x] ~~PR for Studio is ready and reviewed: (please link)~~
- [x] ~~PR for CLI is ready and reviewed: (please link)~~
- [x] ~~PR for Proxy is ready and reviewed: (please link)~~
- [x] ~~The CHANGELOG(s) are updated.~~

When adding new `fiberplane-models` module:

- [x] ~~PR for fp-openapi-rust-gen is ready and reviewed: (please link)~~

When adding new operation types:

- [x] ~~PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
