### PR TITLE
Add descriptions and licenses to generated packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `fiberplane-rs`
+# `fiberplane`
 
 This repository is a monorepo for Rust code that is used throughout Fiberplane's
 product.
@@ -31,11 +31,11 @@ Please see [COMMUNITY.md](COMMUNITY.md) for ways to reach out to us.
 ## Contributing
 
 Please be advised that even though many of our repositories are open for outside
-contributions, `fiberplane-rs` is primarily a **read-only** repository for our
+contributions, `fiberplane` is primarily a **read-only** repository for our
 community. Fiberplane uses this repository to develop new features out in the
 open, and you are encouraged to build custom solutions on top of the source code
-we provide here. Our [issue tracker](https://github.com/fiberplane/fiberplane-rs/issues)
-and [discussions forum](https://github.com/fiberplane/fiberplane-rs/discussions)
+we provide here. Our [issue tracker](https://github.com/fiberplane/fiberplane/issues)
+and [discussions forum](https://github.com/fiberplane/fiberplane/discussions)
 are open to all in case you have issues or questions/suggestions.
 
 For more information, please see [CONTRIBUTING.md](CONTRIBUTING.md).
@@ -46,7 +46,7 @@ See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ## License
 
-All code within the `fiberplane-rs` repository is distributed under the terms of
+All code within the `fiberplane` repository is distributed under the terms of
 both the MIT license and the Apache License (Version 2.0).
 
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT).

--- a/fiberplane-api-client/Cargo.toml
+++ b/fiberplane-api-client/Cargo.toml
@@ -31,6 +31,7 @@ version = "0.3"
 crate-type = ["rlib"]
 edition = "2021"
 name = "fiberplane_api_client"
+description = "Generated API client for Fiberplane API"
 path = "src/lib.rs"
 required-features = []
 

--- a/fiberplane-provider-protocol/Cargo.toml
+++ b/fiberplane-provider-protocol/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "fiberplane-provider-protocol"
+description = "Fiberplane provider protocol for WASM integration"
 version = "2.0.0-alpha.1"
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 bytes = { workspace = true }

--- a/fiberplane-provider-protocol/fiberplane-provider-bindings/Cargo.toml
+++ b/fiberplane-provider-protocol/fiberplane-provider-bindings/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "fiberplane-provider-bindings"
+description = "Fiberplane Provider protocol bindings"
 version = "2.0.0-alpha.1"
 authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2018"
+license = { workspace = true }
 
 [dependencies]
 bytes = { version = "1", features = ["serde"] }


### PR DESCRIPTION
# Description

Fix the last few errors to publish the packages.

As everything is published manually for now, there's no
version change here.

Need to add a ticket to make the generators add the missing
keys. (tracked in FP-2995 and FP-2996)

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] ~~The changes have been tested to be backwards compatible.~~
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] ~~PR for API is ready and reviewed: (please link)~~
- [x] ~~PR for Studio is ready and reviewed: (please link)~~
- [x] ~~PR for CLI is ready and reviewed: (please link)~~
- [x] ~~PR for Proxy is ready and reviewed: (please link)~~
- [x] ~~The CHANGELOG(s) are updated.~~

When adding new `fiberplane-models` module:

- [x] ~~PR for fp-openapi-rust-gen is ready and reviewed: (please link)~~

When adding new operation types:

- [x] ~~PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
