### PR TITLE
chore: move api-client description to correct field

### DIFF
--- a/fiberplane-api-client/Cargo.toml
+++ b/fiberplane-api-client/Cargo.toml
@@ -31,13 +31,13 @@ version = "0.3"
 crate-type = ["rlib"]
 edition = "2021"
 name = "fiberplane_api_client"
-description = "Generated API client for Fiberplane API"
 path = "src/lib.rs"
 required-features = []
 
 [package]
 edition = "2021"
 name = "fiberplane-api-client"
+description = "Generated API client for Fiberplane API"
 
 [package.license]
 workspace = true


### PR DESCRIPTION
# Description

Small mistake from #2 corrected.

API Client has been published with this change already, to not
block `fiberplane` release, and enable PDK publishing

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] ~~The changes have been tested to be backwards compatible.~~
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] ~~PR for API is ready and reviewed: (please link)~~
- [x] ~~PR for Studio is ready and reviewed: (please link)~~
- [x] ~~PR for CLI is ready and reviewed: (please link)~~
- [x] ~~PR for Proxy is ready and reviewed: (please link)~~
- [x] ~~The CHANGELOG(s) are updated.~~

When adding new `fiberplane-models` module:

- [x] ~~PR for fp-openapi-rust-gen is ready and reviewed: (please link)~~

When adding new operation types:

- [x] ~~PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
