### PR TITLE
Fix module exports for sorting

### DIFF
--- a/fiberplane-models/src/sorting.rs
+++ b/fiberplane-models/src/sorting.rs
@@ -30,7 +30,7 @@ impl<T: SortField> Default for Sorting<T> {
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),
-    fp(rust_module = "fiberplane_models::comments")
+    fp(rust_module = "fiberplane_models::sorting")
 )]
 #[cfg_attr(
     feature = "sqlx",
@@ -433,7 +433,7 @@ impl SortField for ViewSortFields {
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),
-    fp(rust_module = "fiberplane_models::notebooks")
+    fp(rust_module = "fiberplane_models::sorting")
 )]
 #[cfg_attr(
     feature = "sqlx",


### PR DESCRIPTION
# Description

Fixes the generated exports for sorting in Studio

# Fixes FP-(issue)

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] The changes have been tested to be backwards compatible.
- [ ] ~The OpenAPI schema and generated client have been updated.~
- [ ] ~PR for API is ready and reviewed: (please link)~
- [ ] ~PR for Studio is ready and reviewed: (please link)~
- [ ] ~PR for CLI is ready and reviewed: (please link)~
- [ ] ~PR for Proxy is ready and reviewed: (please link)~
- [ ] ~The CHANGELOG(s) are updated.~

When adding new `fiberplane-models` module:

- [ ] PR for fp-openapi-rust-gen is ready and reviewed: (please link)

When adding new operation types:

- [ ] PR for fiberplane-ot is ready and reviewed: (please link)

After merging, please merge related PRs ASAP, so others don't get blocked.
