### PR TITLE
Add timeline cell type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,5 +15,6 @@ changes if the major version hasn't changed.
 
 ### Added
 
+- Add support for timeline cell (#5)
 - Add support for pinned views (#336)
 - Initial open-source release of `fiberplane`.

--- a/fiberplane-markdown/src/to_markdown/mod.rs
+++ b/fiberplane-markdown/src/to_markdown/mod.rs
@@ -143,6 +143,9 @@ impl<'a> NotebookConverter<'a> {
                 Cell::Graph(_) => warn!("Ignoring Graph cell because they are not yet supported"),
                 Cell::Log(_) => warn!("Ignoring Log cell because they are not yet supported"),
                 Cell::Table(_) => warn!("Ignoring Table cell because they are not yet supported"),
+                Cell::Timeline(_) => {
+                    warn!("Ignoring Timeline cell because they are not yet supported")
+                }
                 Cell::Discussion(_) => {
                     warn!("Ignoring Discussion cell because they are not yet supported")
                 }

--- a/fiberplane-models/src/notebooks/cells.rs
+++ b/fiberplane-models/src/notebooks/cells.rs
@@ -30,6 +30,7 @@ pub enum Cell {
     Provider(ProviderCell),
     Table(TableCell),
     Text(TextCell),
+    Timeline(TimelineCell),
 }
 
 impl Cell {
@@ -48,6 +49,7 @@ impl Cell {
             Cell::Provider(_) => None,
             Cell::Table(_) => None,
             Cell::Text(cell) => Some(&cell.content),
+            Cell::Timeline(_) => None,
         }
     }
 
@@ -60,7 +62,8 @@ impl Cell {
             | Cell::Graph(_)
             | Cell::Image(_)
             | Cell::Log(_)
-            | Cell::Table(_) => None,
+            | Cell::Table(_)
+            | Cell::Timeline(_) => None,
             Cell::Checkbox(cell) => Some(&cell.formatting),
             Cell::Heading(cell) => Some(&cell.formatting),
             Cell::ListItem(cell) => Some(&cell.formatting),
@@ -77,7 +80,8 @@ impl Cell {
             | Cell::Graph(_)
             | Cell::Image(_)
             | Cell::Log(_)
-            | Cell::Table(_) => false,
+            | Cell::Table(_)
+            | Cell::Timeline(_) => false,
             Cell::Checkbox(_)
             | Cell::Heading(_)
             | Cell::ListItem(_)
@@ -101,6 +105,7 @@ impl Cell {
             Cell::Provider(cell) => &cell.id,
             Cell::Table(cell) => &cell.id,
             Cell::Text(cell) => &cell.id,
+            Cell::Timeline(cell) => &cell.id,
         }
     }
 
@@ -164,6 +169,10 @@ impl Cell {
                 id: id.to_owned(),
                 ..cell.clone()
             }),
+            Cell::Timeline(cell) => Cell::Timeline(TimelineCell {
+                id: id.to_owned(),
+                ..cell.clone()
+            }),
         }
     }
 
@@ -218,6 +227,7 @@ impl Cell {
                 formatting: Formatting::default(),
                 ..*cell
             }),
+            Cell::Timeline(cell) => Cell::Timeline(cell.clone()),
         }
     }
 
@@ -278,7 +288,8 @@ impl Cell {
             | Cell::Divider(_)
             | Cell::Graph(_)
             | Cell::Image(_)
-            | Cell::Table(_) => self.with_text(text),
+            | Cell::Table(_)
+            | Cell::Timeline(_) => self.with_text(text),
         }
     }
 
@@ -326,6 +337,7 @@ impl Cell {
             Cell::Provider(cell) => &mut cell.id,
             Cell::Table(cell) => &mut cell.id,
             Cell::Text(cell) => &mut cell.id,
+            Cell::Timeline(cell) => &mut cell.id,
         }
     }
 
@@ -344,7 +356,8 @@ impl Cell {
             | Cell::Graph(_)
             | Cell::Image(_)
             | Cell::Log(_)
-            | Cell::Table(_) => None,
+            | Cell::Table(_)
+            | Cell::Timeline(_) => None,
         }
     }
 
@@ -363,6 +376,7 @@ impl Cell {
             Cell::Provider(cell) => Some(&mut cell.title),
             Cell::Table(_) => None,
             Cell::Text(cell) => Some(&mut cell.content),
+            Cell::Timeline(_) => None,
         }
     }
 
@@ -381,6 +395,7 @@ impl Cell {
             Cell::Provider(cell) => &cell.intent,
             Cell::Table(_) => "table",
             Cell::Text(_) => "text",
+            Cell::Timeline(_) => "timeline",
         }
     }
 }
@@ -765,6 +780,20 @@ pub struct TextCell {
     #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
+}
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[cfg_attr(
+    feature = "fp-bindgen",
+    derive(Serializable),
+    fp(rust_module = "fiberplane_models::notebooks")
+)]
+#[serde(rename_all = "camelCase")]
+pub struct TimelineCell {
+    pub id: String,
+
+    /// Links to the data to render in the timeline.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub data_links: Vec<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, TypedBuilder)]

--- a/fiberplane-models/src/providers/data.rs
+++ b/fiberplane-models/src/providers/data.rs
@@ -1,4 +1,4 @@
-use crate::timestamps::Timestamp;
+use crate::{events::Event as CoreEvent, timestamps::Timestamp};
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
@@ -152,4 +152,19 @@ pub struct Timeseries {
     /// Whether the series should be rendered. Can be toggled by the user.
     #[serde(default)]
     pub visible: bool,
+}
+
+/// A timeline of events.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(
+    feature = "fp-bindgen",
+    derive(Serializable),
+    fp(rust_module = "fiberplane_models::providers")
+)]
+#[serde(rename_all = "camelCase")]
+pub struct Timeline {
+    pub days: Vec<String>,
+    pub events_by_day: BTreeMap<String, Vec<CoreEvent>>,
+    #[serde(flatten)]
+    pub otel: OtelMetadata,
 }

--- a/fiberplane-models/src/realtime.rs
+++ b/fiberplane-models/src/realtime.rs
@@ -1,4 +1,5 @@
 use crate::comments::{Thread, ThreadItem, UserSummary};
+use crate::events::Event;
 use crate::labels::LabelValidationError;
 use crate::notebooks::operations::Operation;
 use base64uuid::Base64Uuid;
@@ -92,6 +93,15 @@ pub enum ServerRealtimeMessage {
     /// Response from a DebugRequest. Contains some useful data regarding the
     /// connection.
     DebugResponse(DebugResponseMessage),
+
+    /// New event was added to the workspace
+    EventAdded(EventAddedMessage),
+
+    /// Event was updated in the workspace
+    EventUpdated(EventUpdatedMessage),
+
+    /// Event was deleted from the workspace
+    EventDeleted(EventDeletedMessage),
 
     /// Notifies a mentioned user of the fact they've been mentioned by someone
     /// else.
@@ -987,4 +997,46 @@ mod tests {
             panic!("Unexpected error occurred: {err:?}");
         }
     }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[cfg_attr(
+    feature = "fp-bindgen",
+    derive(Serializable),
+    fp(rust_module = "fiberplane_models::realtime")
+)]
+#[serde(rename_all = "camelCase")]
+pub struct EventAddedMessage {
+    /// ID of workspace in which the event was added.
+    pub workspace_id: Base64Uuid,
+    /// The event that was added.
+    pub event: Event,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[cfg_attr(
+    feature = "fp-bindgen",
+    derive(Serializable),
+    fp(rust_module = "fiberplane_models::realtime")
+)]
+#[serde(rename_all = "camelCase")]
+pub struct EventUpdatedMessage {
+    /// ID of workspace in which the event was updated.
+    pub workspace_id: Base64Uuid,
+    /// The event that was updated.
+    pub event: Event,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[cfg_attr(
+    feature = "fp-bindgen",
+    derive(Serializable),
+    fp(rust_module = "fiberplane_models::realtime")
+)]
+#[serde(rename_all = "camelCase")]
+pub struct EventDeletedMessage {
+    /// ID of workspace in which the event was deleted.
+    pub workspace_id: Base64Uuid,
+    /// ID of the event that was deleted.
+    pub event_id: String,
 }

--- a/fiberplane-provider-protocol/fiberplane-provider-bindings/src/types.rs
+++ b/fiberplane-provider-protocol/fiberplane-provider-bindings/src/types.rs
@@ -45,6 +45,7 @@ pub use fiberplane_models::notebooks::TableCellValue;
 pub use fiberplane_models::notebooks::TableColumnDefinition;
 pub use fiberplane_models::notebooks::TextCell;
 pub use fiberplane_models::providers::TextField;
+pub use fiberplane_models::notebooks::TimelineCell;
 pub use fiberplane_models::timestamps::Timestamp;
 pub use fiberplane_models::providers::ValidationError;
 

--- a/fiberplane-provider-protocol/fiberplane-provider-runtime/src/spec/types.rs
+++ b/fiberplane-provider-protocol/fiberplane-provider-runtime/src/spec/types.rs
@@ -29,6 +29,7 @@ pub use fiberplane_models::notebooks::TableCell;
 pub use fiberplane_models::notebooks::TableCellValue;
 pub use fiberplane_models::notebooks::TableColumnDefinition;
 pub use fiberplane_models::notebooks::TextCell;
+pub use fiberplane_models::notebooks::TimelineCell;
 pub use fiberplane_models::providers::CheckboxField;
 pub use fiberplane_models::providers::ConfigField;
 pub use fiberplane_models::providers::DateTimeRangeField;

--- a/fiberplane-provider-protocol/ts-runtime/types.ts
+++ b/fiberplane-provider-protocol/ts-runtime/types.ts
@@ -81,7 +81,8 @@ export type Cell =
     | { type: "log" } & LogCell
     | { type: "provider" } & ProviderCell
     | { type: "table" } & TableCell
-    | { type: "text" } & TextCell;
+    | { type: "text" } & TextCell
+    | { type: "timeline" } & TimelineCell;
 
 export type CheckboxCell = {
     id: string;
@@ -894,6 +895,15 @@ export type TextField = {
      * Whether the provider supports auto-suggestions for this field.
      */
     supportsSuggestions: boolean;
+};
+
+export type TimelineCell = {
+    id: string;
+
+    /**
+     * Links to the data to render in the timeline.
+     */
+    dataLinks?: Array<string>;
 };
 
 export type Timestamp = string;

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -72,6 +72,7 @@ components:
         - $ref: "#/components/schemas/providerCell"
         - $ref: "#/components/schemas/tableCell"
         - $ref: "#/components/schemas/textCell"
+        - $ref: "#/components/schemas/timelineCell"
       discriminator:
         propertyName: type
         mapping:
@@ -87,6 +88,7 @@ components:
           provider: "#/components/schemas/providerCell"
           table: "#/components/schemas/tableCell"
           text: "#/components/schemas/textCell"
+          timeline: "#/components/schemas/timelineCell"
     cellType:
       type: string
       enum:
@@ -102,6 +104,7 @@ components:
         - provider
         - table
         - text
+        - timeline
     checkboxCell:
       type: object
       required:
@@ -456,6 +459,23 @@ components:
           format: int32
         preview:
           type: string
+    timelineCell:
+      type: object
+      required:
+        - type
+        - id
+        - dataLinks
+      properties:
+        type:
+          $ref: "#/components/schemas/cellType"
+        id:
+          type: string
+        dataLinks:
+          type: array
+          items:
+            type: string
+        readOnly:
+          type: boolean
     cellAppendText:
       type: object
       required:
@@ -2289,7 +2309,7 @@ paths:
       operationId: notebook_delete
       summary: "Deletes a notebook"
       description: "Deletes a notebook"
-      tags: 
+      tags:
         - Notebooks
       responses:
         "200":
@@ -2298,7 +2318,7 @@ paths:
       operationId: notebook_update
       summary: "Modifies individual properties of a single notebook"
       description: "Modifies individual properties of a single notebook"
-      tags: 
+      tags:
         - Notebooks
       requestBody:
         description: updated properties
@@ -2317,7 +2337,7 @@ paths:
       operationId: notebook_duplicate
       summary: "Create a copy of the notebook"
       description: "Creates a copy of the specified notebook"
-      tags: 
+      tags:
         - Notebooks
       requestBody:
         description: copy destination


### PR DESCRIPTION
# Description

This PR adds models and events for timeline cell, as well as new events (for events).

Fixes [FP-2777](https://linear.app/fiberplane/issue/FP-2777)

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] The changes have been tested to be backwards compatible.
- [x] The OpenAPI schema and generated client have been updated.
- [x] PR for API is ready and reviewed: https://github.com/fiberplane/api/pull/609
- [x] PR for Studio is ready and reviewed: https://github.com/fiberplane/studio/pull/1376
- ~~[ ] PR for CLI is ready and reviewed: (please link)~~
- ~~[ ] PR for Proxy is ready and reviewed: (please link)~~
- [x] The CHANGELOG(s) are updated.

When adding new `fiberplane-models` module:

- ~~[ ] PR for fp-openapi-rust-gen is ready and reviewed: (please link)~~

When adding new operation types:

- ~~[ ] PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
