### PR TITLE
add forgotten relative time to `UpdateView`

### DIFF
--- a/fiberplane-models/src/views.rs
+++ b/fiberplane-models/src/views.rs
@@ -98,6 +98,9 @@ pub struct UpdateView {
     pub labels: Option<Vec<Label>>,
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relative_time: Option<RelativeTime>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sort_by: Option<NotebookSortFields>,
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -117,6 +120,7 @@ pub struct PinnedView {
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Serialize, Copy, Clone)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -1986,6 +1986,7 @@ components:
       required:
         - name
         - description
+        - color
         - labels
       properties:
         name:
@@ -1995,24 +1996,53 @@ components:
           type: string
         description:
           type: string
+        color:
+          type: number
+          format: int16
         labels:
           type: array
           items:
             $ref: "#/components/schemas/label"
+        relativeTime:
+          $ref: "#/components/schemas/relativeTime"
+        sortBy:
+          type: string
+          enum:
+            - title
+            - created_at
+            - updated_at
+        sortDirection:
+          type: string
+          enum:
+            - ascending
+            - descending
     update_view:
       type: object
       properties:
-        name:
-          type: string
-          format: name
         displayName:
           type: string
         description:
           type: string
+        color:
+          type: number
+          format: int16
         labels:
           type: array
           items:
             $ref: "#/components/schemas/label"
+        relativeTime:
+          $ref: "#/components/schemas/relativeTime"
+        sortBy:
+          type: string
+          enum:
+            - title
+            - created_at
+            - updated_at
+        sortDirection:
+          type: string
+          enum:
+            - ascending
+            - descending
     pinned_view:
       type: object
       properties:


### PR DESCRIPTION
# Description

forgot from views v2 pr. also adds some forgotten properties to openapi schema (doesnt change anything on api client)

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] ~~The changes have been tested to be backwards compatible.~~
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] PR for API is ready and reviewed: https://github.com/fiberplane/api/pull/617
- [x] ~~PR for Studio is ready and reviewed: (please link)~~
- [x] ~~PR for CLI is ready and reviewed: (please link)~~
- [x] ~~PR for Proxy is ready and reviewed: (please link)~~
- [x] ~~The CHANGELOG(s) are updated.~~

When adding new `fiberplane-models` module:

- [x] ~~PR for fp-openapi-rust-gen is ready and reviewed: (please link)~~

When adding new operation types:

- [x] ~~PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
