### PR TITLE
allow `RelativeTime` to be built

### DIFF
--- a/fiberplane-models/src/views.rs
+++ b/fiberplane-models/src/views.rs
@@ -136,7 +136,7 @@ pub enum TimeUnit {
     Days,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq, Serialize, Copy, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Serialize, Copy, Clone, TypedBuilder)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),


### PR DESCRIPTION
# Description

wasn't actually possible before as it was marked `#[non_exhaustive]` but didn't derive a builder

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] ~~The changes have been tested to be backwards compatible.~~
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] ~~PR for API is ready and reviewed: (please link)~~
- [x] ~~PR for Studio is ready and reviewed: (please link)~~
- [x] ~~PR for CLI is ready and reviewed: (please link)~~
- [x] ~~PR for Proxy is ready and reviewed: (please link)~~
- [x] ~~The CHANGELOG(s) are updated.~~

When adding new `fiberplane-models` module:

- [x] ~~PR for fp-openapi-rust-gen is ready and reviewed: (please link)~~

When adding new operation types:

- [x] ~~PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
