### PR TITLE
Fix fiberplane-rs references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@ All notable changes to this project will be documented in this file.
 The format of this file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Please note that while we use [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
-for `fiberplane-rs` as a whole, individual crates published from this repository
-may skip versions to stay in lockstep with the other crates. This means that
-individual crates do not strictly follow _SemVer_ although their versioning
-remains _compatible with_ SemVer, i.e. they will not contain breaking changes
-if the major version hasn't changed.
+for the `fiberplane` repository as a whole, individual crates published from
+this repo may skip versions to stay in lockstep with the other crates. This
+means that individual crates do not strictly follow _SemVer_ although their
+versioning remains _compatible with_ SemVer, i.e. they will not contain breaking
+changes if the major version hasn't changed.
 
 ## [Unreleased]
 
 ### Added
 
 - Add support for pinned views (#336)
-- Initial open-source release of `fiberplane-rs`.
+- Initial open-source release of `fiberplane`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing
 
 Please be advised that even though many of our repositories are open for outside
-contributions, `fiberplane-rs` is primarily a **read-only** repository for our
+contributions, `fiberplane` is primarily a **read-only** repository for our
 community. Fiberplane uses this repository to develop new features out in the
 open, and you are encouraged to build custom solution on top of the source code
-we provide here. Our [issue tracker](https://github.com/fiberplane/fiberplane-rs/issues)
-and [discussions forum](https://github.com/fiberplane/fiberplane-rs/discussions)
+we provide here. Our [issue tracker](https://github.com/fiberplane/fiberplane/issues)
+and [discussions forum](https://github.com/fiberplane/fiberplane/discussions)
 are open to all in case you have issues or questions/suggestions.
 
 Creating pull requests is restricted to Fiberplane employees, because changes to
@@ -33,5 +33,5 @@ token = "Bearer <TOKEN>"
 4. The first time you try to fetch something from Artifactory, it will also
    prompt you for a username and password. The username you should provide is
    your full email address, and the password is the same token you used above.
-   * If you receive a 500 error when trying to access the Artifactory registry,
+   - If you receive a 500 error when trying to access the Artifactory registry,
      you probably used the correct token, but not the right username.


### PR DESCRIPTION
# Description

Fix a few more references to the old repository name.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- ~~[ ] The changes have been tested to be backwards compatible.~~
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] PR for API is ready and reviewed: (please link)~~
- ~~[ ] PR for Studio is ready and reviewed: (please link)~~
- ~~[ ] PR for CLI is ready and reviewed: (please link)~~
- ~~[ ] PR for Proxy is ready and reviewed: (please link)~~
- ~~[ ] The CHANGELOG(s) are updated.~~

When adding new `fiberplane-models` module:

- ~~[ ] PR for fp-openapi-rust-gen is ready and reviewed: (please link)~~

When adding new operation types:

- ~~[ ] PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
