### PR TITLE
Publish v1.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ means that individual crates do not strictly follow _SemVer_ although their
 versioning remains _compatible with_ SemVer, i.e. they will not contain breaking
 changes if the major version hasn't changed.
 
-## [Unreleased]
+## [v1.0.0-beta.1] - 2023-02-14
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-alpha.3"
+version = "1.0.0-beta.1"
 authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -22,15 +22,15 @@ rust-version = "1.64"
 [workspace.dependencies]
 base64uuid = { version = "1.0.0", path = "base64uuid", default-features = false }
 bytes = { version = "1", features = ["serde"] }
-fp-bindgen = { version = "3.0.0-alpha.1" }
-fp-bindgen-support = { version = "3.0.0-alpha.1" }
-fiberplane = { version = "1.0.0-alpha.3", path = "fiberplane" }
-fiberplane-api-client = { version = "1.0.0-alpha.3", path = "fiberplane-api-client" }
-fiberplane-markdown = { version = "1.0.0-alpha.3", path = "fiberplane-markdown" }
-fiberplane-models = { version = "1.0.0-alpha.3", path = "fiberplane-models" }
-fiberplane-provider-bindings = { version = "2.0.0-alpha.1", path = "fiberplane-provider-protocol/fiberplane-provider-bindings" }
-fiberplane-provider-runtime = { version = "2.0.0-alpha.1", path = "fiberplane-provider-protocol/fiberplane-provider-runtime" }
-fiberplane-templates = { version = "1.0.0-alpha.3", path = "fiberplane-templates" }
+fp-bindgen = { version = "3.0.0-beta.1" }
+fp-bindgen-support = { version = "3.0.0-beta.1" }
+fiberplane = { version = "1.0.0-beta.1", path = "fiberplane" }
+fiberplane-api-client = { version = "1.0.0-beta.1", path = "fiberplane-api-client" }
+fiberplane-markdown = { version = "1.0.0-beta.1", path = "fiberplane-markdown" }
+fiberplane-models = { version = "1.0.0-beta.1", path = "fiberplane-models" }
+fiberplane-provider-bindings = { version = "2.0.0-beta.1", path = "fiberplane-provider-protocol/fiberplane-provider-bindings" }
+fiberplane-provider-runtime = { version = "2.0.0-beta.1", path = "fiberplane-provider-protocol/fiberplane-provider-runtime" }
+fiberplane-templates = { version = "1.0.0-beta.1", path = "fiberplane-templates" }
 once_cell = { version = "1.8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/fiberplane-provider-protocol/Cargo.toml
+++ b/fiberplane-provider-protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fiberplane-provider-protocol"
 description = "Fiberplane provider protocol for WASM integration"
-version = "2.0.0-alpha.1"
+version = "2.0.0-beta.1"
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/fiberplane-provider-protocol/fiberplane-provider-bindings/Cargo.toml
+++ b/fiberplane-provider-protocol/fiberplane-provider-bindings/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fiberplane-provider-bindings"
 description = "Fiberplane Provider protocol bindings"
 readme = "README.md"
-version = "2.0.0-alpha.1"
+version = "2.0.0-beta.1"
 authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2018"
 license = { workspace = true }
@@ -10,10 +10,7 @@ license = { workspace = true }
 [dependencies]
 bytes = { version = "1", features = ["serde"] }
 fiberplane-models = { workspace = true }
-fp-bindgen-support = { version = "3.0.0-alpha.1", features = [
-    "async",
-    "guest",
-] }
+fp-bindgen-support = { workspace = true, features = ["async", "guest"] }
 once_cell = { workspace = true }
 rmp-serde = { version = "1.0" }
 rmpv = { version = "1.0.0", features = ["with-serde"] }

--- a/fiberplane-provider-protocol/fiberplane-provider-runtime/Cargo.toml
+++ b/fiberplane-provider-protocol/fiberplane-provider-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fiberplane-provider-runtime"
 description = "Wasmer runtime for Fiberplane Providers"
 readme = "README.md"
-version = "2.0.0-alpha.1"
+version = "2.0.0-beta.1"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/fiberplane-provider-protocol/src/main.rs
+++ b/fiberplane-provider-protocol/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
             bindings_type: BindingsType::RustPlugin(RustPluginConfig {
                 name: "fiberplane-provider-bindings",
                 authors: r#"["Fiberplane <info@fiberplane.com>"]"#,
-                version: "2.0.0-alpha.1",
+                version: "2.0.0-beta.1",
                 dependencies,
             }),
             path,


### PR DESCRIPTION
# Description

Publish `fiberplane-*` v1.0.0-beta.1 and `providers-*` 2.0.0-beta.1.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- ~~[ ] The changes have been tested to be backwards compatible.~~
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] PR for API is ready and reviewed: (please link)~~
- ~~[ ] PR for Studio is ready and reviewed: (please link)~~
- ~~[ ] PR for CLI is ready and reviewed: (please link)~~
- ~~[ ] PR for FPD is ready and reviewed: (please link)~~
- [x] The CHANGELOG(s) are updated.

When adding new `fiberplane-models` module:

- ~~[ ] PR for fp-openapi-rust-gen is ready and reviewed: (please link)~~

When adding new operation types:

- ~~[ ] PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
