### PR TITLE
Update references to example templates

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -19,3 +19,9 @@ You can also follow us on Twitter for updates:
 Did you write a custom provider that you would like to share, or are you
 curious what providers others have contributed? Have a look at our
 [providers repository](https://github.com/fiberplane/providers)!
+
+## Templates
+
+Did you write a custom template that you would like to share, or are you
+curious what templates others have contributed? Have a look at our
+[templates repository](https://github.com/fiberplane/templates)!

--- a/fiberplane-templates/README.md
+++ b/fiberplane-templates/README.md
@@ -22,7 +22,8 @@ This crate includes:
 
 The [Fiberplane CLI](https://github.com/fiberplane/fp) is the recommended way to
 interact with Templates (see the
-[docs](https://github.com/fiberplane/fp#templates) or run `fp help templates`).
+[docs](https://docs.fiberplane.com/docs/working-with-templates) or run
+`fp help templates`).
 
 ## Structure of a Template
 
@@ -50,9 +51,8 @@ function(incidentName='API Outage')
     ])
 ```
 
-See the
-[examples](https://github.com/fiberplane/fiberplane/tree/main/fiberplane-templates/examples)
-for more detailed, use-case-specific templates.
+See the [templates repo](https://github.com/fiberplane/templates) for more
+detailed, use-case-specific templates.
 
 ## Snippets
 
@@ -74,8 +74,8 @@ fp.snippet([
 
 ## Example Templates
 
-There are [example templates](./examples) for various use cases such as incident
-response, root cause analysis, etc.
+There are [example templates](https://github.com/fiberplane/templates) for
+various use cases such as incident response, root cause analysis, etc.
 
 ## Template API Documentation
 

--- a/fiberplane-templates/src/lib.rs
+++ b/fiberplane-templates/src/lib.rs
@@ -20,7 +20,8 @@ This crate includes:
 
 The [Fiberplane CLI](https://github.com/fiberplane/fp) is the recommended way to
 interact with Templates (see the
-[docs](https://github.com/fiberplane/fp#templates) or run `fp help templates`).
+[docs](https://docs.fiberplane.com/docs/working-with-templates) or run
+`fp help templates`).
 
 ## Structure of a Template
 
@@ -48,9 +49,8 @@ function(incidentName='API Outage')
     ])
 ```
 
-See the
-[examples](https://github.com/fiberplane/fiberplane/tree/main/fiberplane-templates/examples)
-for more detailed, use-case-specific templates.
+See the [templates repository](https://github.com/fiberplane/templates) for more
+detailed, use-case-specific templates.
 
 ## Snippets
 


### PR DESCRIPTION
# Description

Updates references to example templates to point to the `templates` repository.

I have not yet removed the `examples` directory from the `fiberplane-templates` crate, because its tests rely on it. So I think it's safer to just accept a little duplication for now.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- ~~[ ] The changes have been tested to be backwards compatible.~~
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] PR for API is ready and reviewed: (please link)~~
- ~~[ ] PR for Studio is ready and reviewed: (please link)~~
- ~~[ ] PR for CLI is ready and reviewed: (please link)~~
- ~~[ ] PR for FPD is ready and reviewed: (please link)~~
- ~~[ ] The CHANGELOG(s) are updated.~~

When adding new `fiberplane-models` module:

- ~~[ ] PR for fp-openapi-rust-gen is ready and reviewed: (please link)~~

When adding new operation types:

- ~~[ ] PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
