### PR TITLE
Fix publishing to Artifactory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "fix-artifactory-publishing"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -45,6 +45,8 @@ jobs:
       - name: Configure Artifactory access token
         run: |
           echo -e "[registries.artifactory]\ntoken = \"Bearer ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}\"" > ~/.cargo/credentials.toml
+          echo -e "[credential]\nhelper = store\n" > ~/.gitconfig
+          echo -e "https://fiberplanebot%40fiberplane.com:${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}@fiberplane.jfrog.io\n" > ~/.git-credentials
 
       - name: Publish changed crates
         run: scripts/publish_crates.py --registry artifactory


### PR DESCRIPTION
# Description

Fixes the authorization for publishing to Artifactory.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- ~~[ ] The changes have been tested to be backwards compatible.~~
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] New models module has been added to API generator script~~
- ~~[ ] PR for API is ready and reviewed: (please link)~~
- ~~[ ] PR for Studio is ready and reviewed: (please link)~~
- ~~[ ] PR for CLI is ready and reviewed: (please link)~~
- ~~[ ] PR for FPD is ready and reviewed: (please link)~~
- ~~[ ] The CHANGELOG(s) are updated.~~

When adding new operation types:

- ~~[ ] PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
