### PR TITLE
[fp-bindgen 3.0.0-beta.2]: Update RustConfig

### DIFF
--- a/fiberplane-provider-protocol/src/main.rs
+++ b/fiberplane-provider-protocol/src/main.rs
@@ -99,12 +99,16 @@ fn main() {
 
         let path = "./fiberplane-provider-bindings";
         fp_bindgen!(BindingConfig {
-            bindings_type: BindingsType::RustPlugin(RustPluginConfig {
-                name: "fiberplane-provider-bindings",
-                authors: r#"["Fiberplane <info@fiberplane.com>"]"#,
-                version: "2.0.0-beta.1",
-                dependencies,
-            }),
+            bindings_type: BindingsType::RustPlugin(
+                RustPluginConfig::builder()
+                    .name("fiberplane-provider-bindings")
+                    .author("Fiberplane <info@fiberplane.com>")
+                    .version("2.0.0-beta.1")
+                    .description("Fiberplane Provider protocol bindings")
+                    .license(RustPluginConfigValue::Workspace)
+                    .dependencies(dependencies)
+                    .build()
+            ),
             path,
         });
         println!("Rust plugin bindings written to `{path}/`.");


### PR DESCRIPTION
This fixes FP-2995. Once fp-bindgen 3.0.0-beta.2 is released, `RustConfig` is replaced with a builder that allows fields like `description`, `readme` and `license` to be set as well. Additionally it allows you to inherit field values from the workspace.

This PR merely updates `RustConfig`, the dependency should still be adjusted in `Cargo.toml` once `fp-bindgen` is released.