### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug.yml
@@ -1,7 +1,7 @@
 name: 🐛 Bug Report
 description: Report a possible bug or regression
 title: "🐛 <TITLE>"
-labels: ["S-To triage"]
+labels: ["triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/01_bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug.yml
@@ -1,0 +1,41 @@
+name: 🐛 Bug Report
+description: Report a possible bug or regression
+title: "🐛 <TITLE>"
+labels: ["S-To triage"]
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for submitting the bug! We'll try to triage it ASAP!
+  - type: markdown
+    attributes:
+      value: |
+        Bug reports that don't follow this template will be closed.
+        Please provide a clear and concise description of what the bug is.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment information
+      description: Is your issue specific to some server setup, or a browser that you use? Please describe your setup here.
+      render: plain text
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: What happened?
+      description: |
+        Please provide a detailed list of steps that reproduce the issue.
+        The more information and included steps, the quicker we can address your report.
+      placeholder: |
+        1.
+        2.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-result
+    attributes:
+      label: Expected result
+      description: Describe what you expected to happen.
+      placeholder: It should not throw an error.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/01_issue.yml
+++ b/.github/ISSUE_TEMPLATE/01_issue.yml
@@ -1,21 +1,23 @@
-name: 🐛 Bug Report
-description: Report a possible bug or regression
+name: 🐛 Report issue
+description: Report a possible bug or other issue
 title: "🐛 <TITLE>"
 labels: ["triage"]
 body:
   - type: markdown
     attributes:
-      value: Thank you for submitting the bug! We'll try to triage it ASAP!
+      value: Thank you for submitting an issue! We'll try to triage it ASAP!
   - type: markdown
     attributes:
       value: |
-        Bug reports that don't follow this template will be closed.
+        Issue reports that don't follow this template will be closed.
         Please provide a clear and concise description of what the bug is.
   - type: textarea
     id: environment
     attributes:
       label: Environment information
-      description: Is your issue specific to some server setup, or a browser that you use? Please describe your setup here.
+      description: |
+        Is your issue specific to some server setup, or a browser that you use?
+        Please describe your setup here.
       render: plain text
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💡 Feature requests
-    url: https://github.com/fiberplane/fiberplane/discussions/new
+    url: https://github.com/fiberplane/fiberplane/discussions/new/choose
     about: "Please use a new Github discussion to propose feature request ideas"
   - name: 🤔 Support
     url: https://discord.gg/MJr7pYzZQ4

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💡 Feature requests
+    url: https://github.com/fiberplane/fiberplane/discussions/new
+    about: "Please use a new Github discussion to propose feature request ideas"
+  - name: 🤔 Support
+    url: https://discord.gg/MJr7pYzZQ4
+    about: "This issue tracker is not for support questions. Visit our community Discord and use the #help channel for assistance!"
+  - name: 🗣️ Chat
+    url: https://discord.gg/MJr7pYzZQ4
+    about: "Our Discord server is active and is used for real-time discussions including contribution collaboration, questions, and more!"
+  - name: 🆘 Code of Conduct Reports
+    url: https://github.com/fiberplane/fiberplane/blob/main/CODE_OF_CONDUCT.md
+    about: "Please use the contact information in our Code of Conduct instead in order to maintain confidentiality."


### PR DESCRIPTION
# Description

This adds an issue template to the repository. I have been pretty blatantly inspired by the setup used by the Rome project, so look here for an example of an almost identical setup: https://github.com/rome/tools/issues/new/choose

If this PR is accepted, I will open similar ones for our other open-source repos.

Fixes FP-1491
