### PR TITLE
Add full query state in AutoSuggestionRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ changes if the major version hasn't changed.
 
 ### Added
 
-- `fiberplane_models`: Added `full_query` field to `AutoSuggestRequest`. The
-  field contains the current state of the Provider Cell request data, URL
-  encoded. It is meant to be used in providers to provide more refined
-  suggestions by examining the context.
+- `fiberplane_models`: Added `other_field_data` field to `AutoSuggestRequest`.
+  The field contains arbitrary other parts of the Provider Cell request data. It
+  is meant to be used in providers to provide more refined suggestions by
+  examining the context.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ changes if the major version hasn't changed.
 
 **Breaking changes!** Some breaking changes occurred between beta versions.
 
+### Added
+
+- `fiberplane_models`: Added `full_query` field to `AutoSuggestRequest`. The
+  field contains the current state of the Provider Cell request data, URL
+  encoded. It is meant to be used in providers to provide more refined
+  suggestions by examining the context.
+
 ### Changed
 
 - `fiberplane_models`: Replaced `AutoSuggestRequest::from_query_data()` with

--- a/fiberplane-models/src/providers/auto_suggest.rs
+++ b/fiberplane-models/src/providers/auto_suggest.rs
@@ -14,7 +14,7 @@ use typed_builder::TypedBuilder;
 )]
 #[non_exhaustive]
 pub struct AutoSuggestRequest {
-    /// The query being typed by the user, up to the focus offset.
+    /// The field being typed by the user, up to the focus offset.
     pub query: String,
 
     /// The query type of the provider we're requesting suggestions for.
@@ -22,6 +22,11 @@ pub struct AutoSuggestRequest {
 
     /// The field in the query form we're requesting suggestions for.
     pub field: String,
+
+    /// The current serialized request in its entirety.
+    /// It is not guaranteed to be valid, but each provider can use this to
+    /// provide context-aware suggestions.
+    pub full_query: String,
 }
 
 impl AutoSuggestRequest {
@@ -33,11 +38,13 @@ impl AutoSuggestRequest {
         let mut query = String::new();
         let mut query_type = String::new();
         let mut field = String::new();
+        let mut full_query = String::new();
         for (key, value) in form_urlencoded::parse(&query_data.data) {
             match key.as_ref() {
                 "query" => query = value.to_string(),
                 "query_type" => query_type = value.to_string(),
                 "field" => field = value.to_string(),
+                "full_query" => full_query = value.to_string(),
                 _ => {}
             }
         }
@@ -65,6 +72,7 @@ impl AutoSuggestRequest {
                 query,
                 query_type,
                 field,
+                full_query,
             }),
             false => Err(Error::ValidationError { errors }),
         }

--- a/fiberplane-models/src/providers/auto_suggest.rs
+++ b/fiberplane-models/src/providers/auto_suggest.rs
@@ -23,10 +23,11 @@ pub struct AutoSuggestRequest {
     /// The field in the query form we're requesting suggestions for.
     pub field: String,
 
-    /// The current serialized request in its entirety.
-    /// It is not guaranteed to be valid, but each provider can use this to
-    /// provide context-aware suggestions.
-    pub full_query: String,
+    /// The current query of the cell being filled by the user.
+    /// The string is a URL encoding of the current query (the
+    /// `application/x-www-form-urlencoded` MIME Type is implied.)
+    /// Each provider can use this to provide context-aware suggestions.
+    pub current_query: Option<String>,
 }
 
 impl AutoSuggestRequest {
@@ -38,13 +39,13 @@ impl AutoSuggestRequest {
         let mut query = String::new();
         let mut query_type = String::new();
         let mut field = String::new();
-        let mut full_query = String::new();
+        let mut current_query = None;
         for (key, value) in form_urlencoded::parse(&query_data.data) {
             match key.as_ref() {
                 "query" => query = value.to_string(),
                 "query_type" => query_type = value.to_string(),
                 "field" => field = value.to_string(),
-                "full_query" => full_query = value.to_string(),
+                "current_query" => current_query = Some(value.to_string()),
                 _ => {}
             }
         }
@@ -72,7 +73,7 @@ impl AutoSuggestRequest {
                 query,
                 query_type,
                 field,
-                full_query,
+                current_query,
             }),
             false => Err(Error::ValidationError { errors }),
         }

--- a/fiberplane-models/src/providers/auto_suggest.rs
+++ b/fiberplane-models/src/providers/auto_suggest.rs
@@ -14,7 +14,7 @@ use typed_builder::TypedBuilder;
 )]
 #[non_exhaustive]
 pub struct AutoSuggestRequest {
-    /// The field being typed by the user, up to the focus offset.
+    /// The value of the field being typed by the user, up to the focus offset.
     pub query: String,
 
     /// The query type of the provider we're requesting suggestions for.
@@ -23,11 +23,14 @@ pub struct AutoSuggestRequest {
     /// The field in the query form we're requesting suggestions for.
     pub field: String,
 
-    /// The current query of the cell being filled by the user.
-    /// The string is a URL encoding of the current query (the
-    /// `application/x-www-form-urlencoded` MIME Type is implied.)
-    /// Each provider can use this to provide context-aware suggestions.
-    pub current_query: Option<String>,
+    /// Some other fields of the cell data.
+    /// The choice of which other fields are sent in the request is
+    /// left to the caller.
+    /// The encoding of the other fields is left to the implementation
+    /// in Studio, and follows the format of
+    /// cells [Query Data](crate::ProviderCell::query_data).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub other_field_data: Option<String>,
 }
 
 impl AutoSuggestRequest {
@@ -39,13 +42,13 @@ impl AutoSuggestRequest {
         let mut query = String::new();
         let mut query_type = String::new();
         let mut field = String::new();
-        let mut current_query = None;
+        let mut other_field_data = None;
         for (key, value) in form_urlencoded::parse(&query_data.data) {
             match key.as_ref() {
                 "query" => query = value.to_string(),
                 "query_type" => query_type = value.to_string(),
                 "field" => field = value.to_string(),
-                "current_query" => current_query = Some(value.to_string()),
+                "other_field_data" => other_field_data = Some(value.to_string()),
                 _ => {}
             }
         }
@@ -73,7 +76,7 @@ impl AutoSuggestRequest {
                 query,
                 query_type,
                 field,
-                current_query,
+                other_field_data,
             }),
             false => Err(Error::ValidationError { errors }),
         }


### PR DESCRIPTION
# Description

This allows the provider to optionally read the context of a completion
request to provide better suggestions

Fixes FP-2731

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] The changes have been tested to be backwards compatible.
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] ~~New models module has been added to API generator script~~
- [x] ~~PR for API is ready and reviewed: (please link)~~
- [x] PR for Studio is ready and reviewed: https://github.com/fiberplane/studio/pull/1452
- [x] ~~PR for CLI is ready and reviewed: (please link)~~
- [x] ~~PR for FPD is ready and reviewed: (please link)~~
- [x] The CHANGELOG(s) are updated.

When adding new operation types:

- [x] ~~PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
