### PR TITLE
Optional crate name in xtask

### DIFF
--- a/fiberplane-ci/src/commands/versions.rs
+++ b/fiberplane-ci/src/commands/versions.rs
@@ -6,94 +6,78 @@ use std::{fs, path::Path};
 use taplo::dom::KeyOrIndex;
 use thiserror::Error;
 
-/// Parameters intended to be set by the xtask implementation, rather than the
-/// CLI user.
-pub struct SetVersionParams<P>
-where
-    P: AsRef<Path>,
-{
-    /// Path of the Cargo file in which to update the version numbers.
-    pub cargo_path: P,
-
-    /// Use this flag if you want the workspace version to be patched as well.
-    pub patch_workspace: bool,
-}
-
 #[derive(Parser)]
 pub struct SetVersionArgs {
-    /// Name of the dependency to bump.
+    /// Name of the crate to bump. If no specific crate is given, set the
+    /// version of the workspace. For non-workspace repositories, specifying
+    /// the crate name is still required.
     #[clap(long, short)]
-    pub dependency: String,
+    pub crate_name: Option<String>,
 
     /// The new version of the dependency.
     #[clap(long, short)]
     pub version: String,
 }
 
-pub fn set_version<P>(params: &SetVersionParams<P>, args: &SetVersionArgs) -> TaskResult
+pub fn set_version<P>(cargo_path: P, args: &SetVersionArgs) -> TaskResult
 where
     P: AsRef<Path>,
 {
-    let cargo_toml =
-        fs::read_to_string(params.cargo_path.as_ref()).context("Cannot read Cargo file")?;
-    let output = set_version_in_toml(&cargo_toml, params.patch_workspace, args)?;
-    fs::write(&params.cargo_path, output).context("Cannot write Cargo file")
+    let cargo_toml = fs::read_to_string(cargo_path.as_ref()).context("Cannot read Cargo file")?;
+    let output = set_version_in_toml(&cargo_toml, args)?;
+    fs::write(cargo_path, output).context("Cannot write Cargo file")
 }
 
-fn set_version_in_toml(
-    cargo_toml: &str,
-    patch_workspace: bool,
-    args: &SetVersionArgs,
-) -> anyhow::Result<String> {
+fn set_version_in_toml(cargo_toml: &str, args: &SetVersionArgs) -> anyhow::Result<String> {
     let root = TomlNode::parse(cargo_toml)?;
     let mut patcher = TomlPatcher::new(root.clone()).unwrap();
 
-    match root.get_string("package.name") {
-        Some(package_name) if package_name == args.dependency => {
-            if root.get_bool("package.version.workspace") != Some(true) || patch_workspace {
-                patcher
-                    .set_string("package.version", &args.version)
-                    .map_err(|err| VersionError::PatchError(err.to_string()))?;
+    if let Some(crate_name) = args.crate_name.as_ref() {
+        match root.get_string("package.name") {
+            Some(package_name) if &package_name == crate_name => {
+                if root.get_bool("package.version.workspace") != Some(true) {
+                    patcher
+                        .set_string("package.version", &args.version)
+                        .map_err(|err| VersionError::PatchError(err.to_string()))?;
+                }
             }
+            _ => {}
         }
-        _ => {}
-    }
 
-    if patch_workspace {
+        patcher
+            .set_string(format!("dependencies.{crate_name}.version"), &args.version)
+            .map_err(|err| VersionError::PatchError(err.to_string()))?;
+        patcher
+            .set_string(
+                format!("workspace.dependencies.{crate_name}.version"),
+                &args.version,
+            )
+            .map_err(|err| VersionError::PatchError(err.to_string()))?;
+
+        if let Some((path, _)) = args
+            .crate_name
+            .as_ref()
+            .and_then(|crate_name| root.get_patch(crate_name))
+        {
+            let maybe_branch = root.get_string(&format!("patch.*.{}.branch", crate_name));
+            let table_path = path
+                .iter()
+                .take(path.len() - 1)
+                .map(KeyOrIndex::to_string)
+                .collect::<Vec<_>>()
+                .join(".");
+            patcher
+                .comment_out_table_key_and_replace_value(&table_path, &crate_name, |value| {
+                    match &maybe_branch {
+                        Some(branch) => value.replace(branch, "main"),
+                        None => value,
+                    }
+                })
+                .map_err(|err| VersionError::PatchError(err.to_string()))?;
+        }
+    } else {
         patcher
             .set_string("workspace.package.version", &args.version)
-            .map_err(|err| VersionError::PatchError(err.to_string()))?;
-    }
-
-    patcher
-        .set_string(
-            format!("dependencies.{}.version", args.dependency),
-            &args.version,
-        )
-        .map_err(|err| VersionError::PatchError(err.to_string()))?;
-
-    patcher
-        .set_string(
-            format!("workspace.dependencies.{}.version", args.dependency),
-            &args.version,
-        )
-        .map_err(|err| VersionError::PatchError(err.to_string()))?;
-
-    if let Some((path, _)) = root.get_patch(&args.dependency) {
-        let maybe_branch = root.get_string(&format!("patch.*.{}.branch", args.dependency));
-        let table_path = path
-            .iter()
-            .take(path.len() - 1)
-            .map(KeyOrIndex::to_string)
-            .collect::<Vec<_>>()
-            .join(".");
-        patcher
-            .comment_out_table_key_and_replace_value(&table_path, &args.dependency, |value| {
-                match &maybe_branch {
-                    Some(branch) => value.replace(branch, "main"),
-                    None => value,
-                }
-            })
             .map_err(|err| VersionError::PatchError(err.to_string()))?;
     }
 
@@ -113,7 +97,86 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn test_set_version_in_workspace_toml() {
+    fn test_set_crate_version_in_workspace_toml() {
+        let workspace_toml = r#"[workspace]
+members = [
+    "base64uuid",
+    "fiberplane",
+    "fiberplane-api-client",
+    "fiberplane-provider-protocol/fiberplane-provider-bindings",
+]
+
+[workspace.package]
+version = "1.0.0-alpha.1"
+authors = ["Fiberplane <info@fiberplane.com>"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/fiberplane/fiberplane"
+rust-version = "1.64"
+
+[workspace.dependencies]
+base64uuid = { version = "1.0.0", path = "base64uuid", default-features = false }
+bytes = "1"
+fp-bindgen = { version = "3.0.0-alpha.1" }
+fiberplane = { version = "1.0.0-alpha.1", path = "fiberplane" }
+fiberplane-api-client = { version = "1.0.0-alpha.1", path = "fiberplane-api-client" }
+once_cell = { version = "1.8" }
+vergen = { version = "7.4.2", default-features = false, features = [
+    "build",
+    "git",
+] }
+
+[patch.crates-io]
+#fp-bindgen = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "main" }
+#fp-bindgen = { path = "../fp-bindgen/fp-bindgen" }
+"#;
+
+        let expected_toml = r#"[workspace]
+members = [
+    "base64uuid",
+    "fiberplane",
+    "fiberplane-api-client",
+    "fiberplane-provider-protocol/fiberplane-provider-bindings",
+]
+
+[workspace.package]
+version = "1.0.0-alpha.1"
+authors = ["Fiberplane <info@fiberplane.com>"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/fiberplane/fiberplane"
+rust-version = "1.64"
+
+[workspace.dependencies]
+base64uuid = { version = "1.0.0", path = "base64uuid", default-features = false }
+bytes = "1"
+fp-bindgen = { version = "3.0.0-alpha.1" }
+fiberplane = { version = "1.0.0-beta.1", path = "fiberplane" }
+fiberplane-api-client = { version = "1.0.0-alpha.1", path = "fiberplane-api-client" }
+once_cell = { version = "1.8" }
+vergen = { version = "7.4.2", default-features = false, features = [
+    "build",
+    "git",
+] }
+
+[patch.crates-io]
+#fp-bindgen = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "main" }
+#fp-bindgen = { path = "../fp-bindgen/fp-bindgen" }
+"#;
+
+        let output = set_version_in_toml(
+            workspace_toml,
+            &SetVersionArgs {
+                crate_name: Some("fiberplane".to_owned()),
+                version: "1.0.0-beta.1".to_owned(),
+            },
+        )
+        .unwrap();
+        assert_eq!(&output, expected_toml);
+    }
+
+    #[test]
+    fn test_set_workspace_version_in_workspace_toml() {
         let workspace_toml = r#"[workspace]
 members = [
     "base64uuid",
@@ -167,7 +230,7 @@ rust-version = "1.64"
 base64uuid = { version = "1.0.0", path = "base64uuid", default-features = false }
 bytes = "1"
 fp-bindgen = { version = "3.0.0-alpha.1" }
-fiberplane = { version = "1.0.0-beta.1", path = "fiberplane" }
+fiberplane = { version = "1.0.0-alpha.1", path = "fiberplane" }
 fiberplane-api-client = { version = "1.0.0-alpha.1", path = "fiberplane-api-client" }
 once_cell = { version = "1.8" }
 vergen = { version = "7.4.2", default-features = false, features = [
@@ -182,9 +245,8 @@ vergen = { version = "7.4.2", default-features = false, features = [
 
         let output = set_version_in_toml(
             workspace_toml,
-            true,
             &SetVersionArgs {
-                dependency: "fiberplane".to_owned(),
+                crate_name: None,
                 version: "1.0.0-beta.1".to_owned(),
             },
         )
@@ -220,9 +282,8 @@ fiberplane-api-client = { workspace = true, optional = true }
 
         let output = set_version_in_toml(
             crate_toml,
-            false,
             &SetVersionArgs {
-                dependency: "fiberplane".to_owned(),
+                crate_name: Some("fiberplane".to_owned()),
                 version: "1.0.0-beta.1".to_owned(),
             },
         )
@@ -258,9 +319,8 @@ fiberplane-api-client = { version = "1.0.0-beta.1", optional = true }
 
         let output = set_version_in_toml(
             crate_toml,
-            false,
             &SetVersionArgs {
-                dependency: "fiberplane-api-client".to_owned(),
+                crate_name: Some("fiberplane-api-client".to_owned()),
                 version: "1.0.0-beta.1".to_owned(),
             },
         )
@@ -302,9 +362,8 @@ fiberplane-api-client = { version = "1.0.0-beta.1", optional = true }
 
         let output = set_version_in_toml(
             crate_toml,
-            false,
             &SetVersionArgs {
-                dependency: "fiberplane-api-client".to_owned(),
+                crate_name: Some("fiberplane-api-client".to_owned()),
                 version: "1.0.0-beta.1".to_owned(),
             },
         )
@@ -328,9 +387,8 @@ fiberplane-api-client = { workspace = true, optional = true }
 
         let output = set_version_in_toml(
             crate_toml,
-            false,
             &SetVersionArgs {
-                dependency: "fiberplane".to_owned(),
+                crate_name: Some("fiberplane".to_owned()),
                 version: "1.0.0-beta.1".to_owned(),
             },
         )

--- a/fiberplane-ci/src/lib.rs
+++ b/fiberplane-ci/src/lib.rs
@@ -1,19 +1,4 @@
 pub mod commands;
 pub mod utils;
 
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-pub enum TaskError {
-    /// The user is trying to perform a request that we consider invalid.
-    #[error("Invalid request: {0}")]
-    InvalidRequest(String),
-
-    #[error("Unknown command")]
-    UnknownCommand,
-
-    #[error("Workspace error: {0}")]
-    WorkspaceError(String),
-}
-
 pub type TaskResult = anyhow::Result<()>;

--- a/xtask/src/commands/versions.rs
+++ b/xtask/src/commands/versions.rs
@@ -39,10 +39,10 @@ fn handle_set_version(args: &SetVersionArgs) -> TaskResult {
 
     if let Some(crate_name) = args.crate_name.as_ref() {
         if crates_using_workspace_version.contains(crate_name) {
-            return Err(anyhow!(
+           bail!(
                 "Crates that use the workspace version cannot have their version set independently. \
                 Please set the workspace version to bump them (omit --crate-name).",
-            ));
+            );
         }
     }
 

--- a/xtask/src/commands/versions.rs
+++ b/xtask/src/commands/versions.rs
@@ -1,7 +1,7 @@
 use crate::constants::*;
+use anyhow::anyhow;
 use clap::Parser;
 use fiberplane_ci::utils::toml_query::TomlNode;
-use fiberplane_ci::TaskError;
 use fiberplane_ci::{commands::versions::*, TaskResult};
 
 #[derive(Parser)]
@@ -26,58 +26,45 @@ pub fn handle_version_command(args: &VersionArgs) -> TaskResult {
 fn handle_set_version(args: &SetVersionArgs) -> TaskResult {
     let all_crates = TomlNode::from_file("Cargo.toml")?
         .get_string_array("workspace.members")
-        .ok_or_else(|| TaskError::WorkspaceError("Cannot determine workspace members".into()))?;
+        .ok_or_else(|| anyhow!("Cannot determine workspace members"))?;
     let crates_using_workspace_version: Vec<_> = all_crates
         .into_iter()
         .filter(|crate_name| {
             TomlNode::from_file(format!("{crate_name}/Cargo.toml"))
                 .ok()
                 .and_then(|node| node.get_bool("package.version.workspace"))
-                == Some(true)
+                .unwrap_or_default()
         })
         .collect();
 
-    let patch_workspace = args.dependency == "fiberplane";
-    if crates_using_workspace_version.contains(&args.dependency) && !patch_workspace {
-        return Err(TaskError::InvalidRequest(
-            "Crates that use the workspace version cannot have their version set independently. \
-            Please set the version for the `fiberplane` crate to bump them."
-                .into(),
-        )
-        .into());
+    if let Some(crate_name) = args.crate_name.as_ref() {
+        if crates_using_workspace_version.contains(crate_name) {
+            return Err(anyhow!(
+                "Crates that use the workspace version cannot have their version set independently. \
+                Please set the workspace version to bump them (omit --crate-name).",
+            ));
+        }
     }
 
-    set_version(
-        &SetVersionParams {
-            cargo_path: "Cargo.toml",
-            patch_workspace,
-        },
-        args,
-    )?;
+    set_version("Cargo.toml", args)?;
 
-    if patch_workspace {
+    if let Some(crate_name) = args.crate_name.as_ref() {
+        set_version(format!("{crate_name}/Cargo.toml"), args)?;
+
+        println!("{SUCCESS}Version updated.");
+    } else {
         for crate_name in crates_using_workspace_version {
             set_version(
-                &SetVersionParams {
-                    cargo_path: "Cargo.toml",
-                    patch_workspace,
-                },
+                "Cargo.toml",
                 &SetVersionArgs {
-                    dependency: crate_name,
+                    crate_name: Some(crate_name.clone()),
                     version: args.version.clone(),
                 },
             )?;
         }
-    } else {
-        set_version(
-            &SetVersionParams {
-                cargo_path: format!("{}/Cargo.toml", args.dependency),
-                patch_workspace,
-            },
-            args,
-        )?;
+
+        println!("{SUCCESS}Workspace version updated.");
     }
 
-    println!("{SUCCESS}Version updated.");
     Ok(())
 }

--- a/xtask/src/commands/versions.rs
+++ b/xtask/src/commands/versions.rs
@@ -1,5 +1,5 @@
 use crate::constants::*;
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use clap::Parser;
 use fiberplane_ci::utils::toml_query::TomlNode;
 use fiberplane_ci::{commands::versions::*, TaskResult};
@@ -39,7 +39,7 @@ fn handle_set_version(args: &SetVersionArgs) -> TaskResult {
 
     if let Some(crate_name) = args.crate_name.as_ref() {
         if crates_using_workspace_version.contains(crate_name) {
-           bail!(
+            bail!(
                 "Crates that use the workspace version cannot have their version set independently. \
                 Please set the workspace version to bump them (omit --crate-name).",
             );


### PR DESCRIPTION
# Description

This PR makes `--crate-name` optional in the set version `xtask` handler. If omitted, it will set the workspace version. This makes the behavior a little bit more straightforward compared to the old situation where the version for the `fiberplane` crate would implicitly set the workspace version. This in turn will help our `fpx` command, since that it won't need repository-specific knowledge to bump workspace versions.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- ~~[ ] The changes have been tested to be backwards compatible.~~
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] New models module has been added to API generator script~~
- ~~[ ] PR for API is ready and reviewed: (please link)~~
- ~~[ ] PR for Studio is ready and reviewed: (please link)~~
- ~~[ ] PR for CLI is ready and reviewed: (please link)~~
- ~~[ ] PR for FPD is ready and reviewed: (please link)~~
- ~~[ ] The CHANGELOG(s) are updated.~~

When adding new operation types:

- ~~[ ] PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
