### PR TITLE
Rename Event in the providers module to ProviderEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@ changes if the major version hasn't changed.
 
 - `fiberplane-models`: Replaced `AutoSuggestRequest::from_query_data()` with
   `AutoSuggestRequest::parse()` for consistency with the PDK.
+- Rename Event in the providers module to ProviderEvent (#26)
 - `fiberplane-models`: `UpdateView` field `color` is now optional (#27)
-- `fiberplane-models`: All `u32` fields declared within `Pagination` no longer use 
+- `fiberplane-models`: All `u32` fields declared within `Pagination` no longer use
   serde's built-in deserialization but a custom visitor. This is a workaround for a
   bug inside axum `Query` <-> serde impl: https://github.com/tokio-rs/axum/discussions/1359 (#27)
 

--- a/fiberplane-models/src/events.rs
+++ b/fiberplane-models/src/events.rs
@@ -2,8 +2,7 @@ use base64uuid::Base64Uuid;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use time::OffsetDateTime;
 use typed_builder::TypedBuilder;
 

--- a/fiberplane-models/src/events.rs
+++ b/fiberplane-models/src/events.rs
@@ -2,7 +2,8 @@ use base64uuid::Base64Uuid;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap};
 use time::OffsetDateTime;
 use typed_builder::TypedBuilder;
 
@@ -15,9 +16,16 @@ use typed_builder::TypedBuilder;
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Event {
+    /// Unique identifier associated with this event
     pub id: Base64Uuid,
+
+    /// The title describing the event
     pub title: String,
+
+    /// Labels associated with the event
     pub labels: HashMap<String, Option<String>>,
+
+    /// The moment the event occurred
     #[serde(with = "time::serde::rfc3339")]
     pub occurrence_time: OffsetDateTime,
 
@@ -38,9 +46,11 @@ pub struct Event {
 pub struct NewEvent {
     #[builder(setter(into))]
     pub title: String,
+
     #[builder(default, setter(into, strip_option))]
     #[serde(default)]
     pub labels: Option<HashMap<String, Option<String>>>,
+
     #[builder(default, setter(into))]
     #[serde(default, with = "time::serde::rfc3339::option")]
     pub time: Option<OffsetDateTime>,

--- a/fiberplane-models/src/providers/data.rs
+++ b/fiberplane-models/src/providers/data.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use std::collections::BTreeMap;
 use typed_builder::TypedBuilder;
 
-/// A single event.
+/// A single event that is used within providers.
 ///
 /// Events occur at a given time and optionally last until a given end time.
 /// They may contain both event-specific metadata as well as OpenTelemetry
@@ -19,7 +19,7 @@ use typed_builder::TypedBuilder;
 )]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
-pub struct Event {
+pub struct ProviderEvent {
     pub time: Timestamp,
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This will prevent naming collision when using using these structs with `fp-bindgen`. Merging the conflicting structs proved to be more complicated due to the large surface area.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] ~~The changes have been tested to be backwards compatible.~~
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] ~~New models module has been added to API generator script~~
- [x] PR for API is ready and reviewed: (https://github.com/fiberplane/api/pull/624)
- [x] PR for Studio is ready and reviewed: (https://github.com/fiberplane/studio/pull/1458)
- [x] PR for CLI is ready and reviewed: (https://github.com/fiberplane/fp/pull/231)
- [x] PR for FPD is ready and reviewed: (https://github.com/fiberplane/fpd/pull/128)
- [x] PR for Providers is ready: (https://github.com/fiberplane/providers/pull/28) 
- [x] The CHANGELOG(s) are updated.

When adding new operation types:

- [x] PR for fiberplane-ot is ready and reviewed: (https://github.com/fiberplane/fiberplane-ot/pull/8)

After merging, please merge related PRs ASAP, so others don't get blocked.
