### PR TITLE
views fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,19 +17,28 @@ changes if the major version hasn't changed.
 
 ### Added
 
-- `fiberplane_models`: Added `other_field_data` field to `AutoSuggestRequest`.
+- `fiberplane-models`: Added `other_field_data` field to `AutoSuggestRequest`.
   The field contains arbitrary other parts of the Provider Cell request data. It
   is meant to be used in providers to provide more refined suggestions by
   examining the context.
+- `fiberplane-api-client`: Added new query parameters `sort_by` and `sort_direction`
+  to the `notebook_search` endpoint (#27)
+- `fiberplane-api-client`: Existing endpoint `pinned_views_get` now returns `Vec<View>`
+  instead of `Vec<PinnedView>` (#27)
 
 ### Changed
 
-- `fiberplane_models`: Replaced `AutoSuggestRequest::from_query_data()` with
+- `fiberplane-models`: Replaced `AutoSuggestRequest::from_query_data()` with
   `AutoSuggestRequest::parse()` for consistency with the PDK.
+- `fiberplane-models`: `UpdateView` field `color` is now optional (#27)
+- `fiberplane-models`: All `u32` fields declared within `Pagination` no longer use 
+  serde's built-in deserialization but a custom visitor. This is a workaround for a
+  bug inside axum `Query` <-> serde impl: https://github.com/tokio-rs/axum/discussions/1359 (#27)
 
 ### Removed
 
 - Support for the legacy provider protocol has been removed.
+- `fiberplane-models`: The `PaginatedSearch` struct has been removed (#27)
 
 ## [v1.0.0-beta.1] - 2023-02-14
 

--- a/fiberplane-api-client/src/lib.rs
+++ b/fiberplane-api-client/src/lib.rs
@@ -1390,6 +1390,8 @@ pub async fn proxy_supported_query_types(
 pub async fn notebook_search(
     client: &ApiClient,
     workspace_id: base64uuid::Base64Uuid,
+    sort_by: Option<&str>,
+    sort_direction: Option<&str>,
     payload: models::NotebookSearch,
 ) -> Result<Vec<models::NotebookSummary>> {
     let mut builder = client.request(
@@ -1399,6 +1401,12 @@ pub async fn notebook_search(
             workspace_id = workspace_id,
         ),
     )?;
+    if let Some(sort_by) = sort_by {
+        builder = builder.query(&[("sort_by", sort_by)]);
+    }
+    if let Some(sort_direction) = sort_direction {
+        builder = builder.query(&[("sort_direction", sort_direction)]);
+    }
     builder = builder.json(&payload);
     let response = builder.send().await?.error_for_status()?.json().await?;
 

--- a/fiberplane-api-client/src/lib.rs
+++ b/fiberplane-api-client/src/lib.rs
@@ -1139,7 +1139,7 @@ pub async fn workspace_picture_update(
 pub async fn pinned_views_get(
     client: &ApiClient,
     workspace_id: base64uuid::Base64Uuid,
-) -> Result<Vec<models::PinnedView>> {
+) -> Result<Vec<models::View>> {
     let mut builder = client.request(
         Method::GET,
         &format!(

--- a/fiberplane-models/src/lib.rs
+++ b/fiberplane-models/src/lib.rs
@@ -19,6 +19,10 @@ products, including but not limited to:
 
 */
 
+use serde::de::{Error, Unexpected, Visitor};
+use serde::Deserializer;
+use std::fmt;
+
 pub mod blobs;
 pub mod comments;
 pub mod data_sources;
@@ -48,5 +52,54 @@ fn debug_print_bytes(bytes: impl AsRef<[u8]>) -> String {
         format!("{}...", String::from_utf8_lossy(&bytes[..100]))
     } else {
         String::from_utf8_lossy(bytes).to_string()
+    }
+}
+
+// workaround for "invalid type: string "1", expected u32" bug in query string:
+// - https://linear.app/fiberplane/issue/FP-3066#comment-59e010ae
+// - https://github.com/tokio-rs/axum/discussions/1359
+// use on struct like this: #[serde(deserialize_with = "crate::deserialize_u32")]
+pub(crate) fn deserialize_u32<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u32, D::Error> {
+    deserializer.deserialize_str(U32Visitor)
+}
+
+struct U32Visitor;
+
+impl<'de> Visitor<'de> for U32Visitor {
+    type Value = u32;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("an u32")
+    }
+
+    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(v)
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        v.parse()
+            .map_err(|_| Error::invalid_type(Unexpected::Str(v), &self))
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        v.parse()
+            .map_err(|_| Error::invalid_type(Unexpected::Str(v), &self))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        v.parse()
+            .map_err(|_| Error::invalid_type(Unexpected::Str(&v), &self))
     }
 }

--- a/fiberplane-models/src/sorting.rs
+++ b/fiberplane-models/src/sorting.rs
@@ -1,9 +1,7 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
-use serde::de::{Error, Unexpected, Visitor};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use std::fmt::Formatter;
 use strum_macros::IntoStaticStr;
 use typed_builder::TypedBuilder;
 
@@ -75,13 +73,13 @@ pub trait SortField {
 pub struct Pagination {
     #[serde(
         default = "Pagination::default_page",
-        deserialize_with = "deserialize_u32"
+        deserialize_with = "crate::deserialize_u32"
     )]
     pub page: u32,
 
     #[serde(
         default = "Pagination::default_limit",
-        deserialize_with = "deserialize_u32"
+        deserialize_with = "crate::deserialize_u32"
     )]
     pub limit: u32,
 }
@@ -121,51 +119,6 @@ impl Default for Pagination {
             page: Pagination::default_page(),
             limit: Pagination::default_limit(),
         }
-    }
-}
-
-pub fn deserialize_u32<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u32, D::Error> {
-    deserializer.deserialize_str(U32Visitor)
-}
-
-struct U32Visitor;
-
-impl<'de> Visitor<'de> for U32Visitor {
-    type Value = u32;
-
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-        formatter.write_str("an u32")
-    }
-
-    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(v)
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        v.parse()
-            .map_err(|_| Error::invalid_type(Unexpected::Str(v), &self))
-    }
-
-    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        v.parse()
-            .map_err(|_| Error::invalid_type(Unexpected::Str(v), &self))
-    }
-
-    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        v.parse()
-            .map_err(|_| Error::invalid_type(Unexpected::Str(&v), &self))
     }
 }
 

--- a/fiberplane-models/src/sorting.rs
+++ b/fiberplane-models/src/sorting.rs
@@ -116,16 +116,6 @@ impl Default for Pagination {
     }
 }
 
-/// Simple struct which includes both `sort` and `pagination`, to be used with `#[serde(flatten)]`
-// Debug will automatically put a bound on the generic param = `T: Debug`: https://stackoverflow.com/a/50322720/11494565
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct PaginatedSearch<T: SortField> {
-    #[serde(flatten)]
-    pub sort: Sorting<T>,
-    #[serde(flatten)]
-    pub pagination: Pagination,
-}
-
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, IntoStaticStr)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(

--- a/fiberplane-models/src/sorting.rs
+++ b/fiberplane-models/src/sorting.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
-use serde::{Deserialize, Serialize};
+use serde::de::{Error, Unexpected, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::borrow::Cow;
+use std::fmt::Formatter;
 use strum_macros::IntoStaticStr;
 use typed_builder::TypedBuilder;
 
@@ -71,10 +73,16 @@ pub trait SortField {
 )]
 #[non_exhaustive]
 pub struct Pagination {
-    #[serde(default = "Pagination::default_page")]
+    #[serde(
+        default = "Pagination::default_page",
+        deserialize_with = "deserialize_u32"
+    )]
     pub page: u32,
 
-    #[serde(default = "Pagination::default_limit")]
+    #[serde(
+        default = "Pagination::default_limit",
+        deserialize_with = "deserialize_u32"
+    )]
     pub limit: u32,
 }
 
@@ -113,6 +121,51 @@ impl Default for Pagination {
             page: Pagination::default_page(),
             limit: Pagination::default_limit(),
         }
+    }
+}
+
+pub fn deserialize_u32<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u32, D::Error> {
+    deserializer.deserialize_str(U32Visitor)
+}
+
+struct U32Visitor;
+
+impl<'de> Visitor<'de> for U32Visitor {
+    type Value = u32;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        formatter.write_str("an u32")
+    }
+
+    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(v)
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        v.parse()
+            .map_err(|_| Error::invalid_type(Unexpected::Str(v), &self))
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        v.parse()
+            .map_err(|_| Error::invalid_type(Unexpected::Str(v), &self))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        v.parse()
+            .map_err(|_| Error::invalid_type(Unexpected::Str(&v), &self))
     }
 }
 

--- a/fiberplane-models/src/views.rs
+++ b/fiberplane-models/src/views.rs
@@ -1,6 +1,6 @@
 use crate::labels::Label;
 use crate::names::Name;
-use crate::sorting::{NotebookSortFields, PaginatedSearch, SortDirection, ViewSortFields};
+use crate::sorting::{NotebookSortFields, Pagination, SortDirection, Sorting, ViewSortFields};
 use base64uuid::Base64Uuid;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
@@ -43,7 +43,9 @@ pub struct View {
 #[serde(rename_all = "camelCase")]
 pub struct ViewQuery {
     #[serde(flatten)]
-    pub search: PaginatedSearch<ViewSortFields>,
+    pub sort: Sorting<ViewSortFields>,
+    #[serde(flatten)]
+    pub pagination: Pagination,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]

--- a/fiberplane-models/src/views.rs
+++ b/fiberplane-models/src/views.rs
@@ -92,7 +92,8 @@ pub struct UpdateView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[builder(default)]
-    pub color: i16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<i16>,
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<Label>>,

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -3471,6 +3471,18 @@ paths:
       description: Search for notebooks
       tags:
         - Notebooks
+      parameters:
+        - in: query
+          name: sort_by
+          description: Sort the resulting list by the following field (defaults to created_at)
+          schema:
+            type: string
+            enum:
+              - "title"
+              - "created_at"
+              - "updated_at"
+          required: false
+        - $ref: "#/components/parameters/sortDirection"
       requestBody:
         required: true
         description: Notebook search payload

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -4162,7 +4162,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/pinned_view"
+                  $ref: "#/components/schemas/view"
     post:
       operationId: pinned_view_add
       description: Add an existing view to the pinned views list


### PR DESCRIPTION
# Description

Fixes FP-3068
Fixes FP-3067
Fixes FP-3066

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] The changes have been tested to be backwards compatible.
- [x] The OpenAPI schema and generated client have been updated.
- [x] ~~New models module has been added to API generator script~~
- [x] PR for API is ready and reviewed: https://github.com/fiberplane/api/pull/625
- [x] ~~PR for Studio is ready and reviewed: (please link)~~
- [x] PR for CLI is ready and reviewed: https://github.com/fiberplane/fp/pull/232
- [x] ~~PR for FPD is ready and reviewed: (please link)~~
- [x] The CHANGELOG(s) are updated.

When adding new operation types:

- [x] ~~PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
