### PR TITLE
allow setting optional view fields to explicit null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ changes if the major version hasn't changed.
 - `fiberplane-models`: All `u32` fields declared within `Pagination` no longer use
   serde's built-in deserialization but a custom visitor. This is a workaround for a
   bug inside axum `Query` <-> serde impl: https://github.com/tokio-rs/axum/discussions/1359 (#27)
+- `fiberplane-models`: `UpdateView` fields `description`, `relative_time`, `sort_by`
+  and `sort_direction` now take an `Option<Option<T>>` instead of previously an `Option<T>`. (#31)
 
 ### Removed
 

--- a/fiberplane-models/src/lib.rs
+++ b/fiberplane-models/src/lib.rs
@@ -20,7 +20,7 @@ products, including but not limited to:
 */
 
 use serde::de::{Error, Unexpected, Visitor};
-use serde::Deserializer;
+use serde::{Deserialize, Deserializer};
 use std::fmt;
 
 pub mod blobs;
@@ -53,6 +53,16 @@ fn debug_print_bytes(bytes: impl AsRef<[u8]>) -> String {
     } else {
         String::from_utf8_lossy(bytes).to_string()
     }
+}
+
+/// Any value that is present is considered Some value, including null
+// https://github.com/serde-rs/serde/issues/984#issuecomment-314143738
+pub(crate) fn deserialize_some<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Deserialize::deserialize(deserializer).map(Some)
 }
 
 // workaround for "invalid type: string "1", expected u32" bug in query string:

--- a/fiberplane-models/src/views.rs
+++ b/fiberplane-models/src/views.rs
@@ -91,8 +91,12 @@ pub struct UpdateView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
     #[builder(default, setter(into))]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "crate::deserialize_some",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub description: Option<Option<String>>,
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color: Option<i16>,
@@ -100,14 +104,26 @@ pub struct UpdateView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<Label>>,
     #[builder(default)]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub relative_time: Option<RelativeTime>,
+    #[serde(
+        default,
+        deserialize_with = "crate::deserialize_some",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub relative_time: Option<Option<RelativeTime>>,
     #[builder(default)]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sort_by: Option<NotebookSortFields>,
+    #[serde(
+        default,
+        deserialize_with = "crate::deserialize_some",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sort_by: Option<Option<NotebookSortFields>>,
     #[builder(default)]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sort_direction: Option<SortDirection>,
+    #[serde(
+        default,
+        deserialize_with = "crate::deserialize_some",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sort_direction: Option<Option<SortDirection>>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2023,6 +2023,7 @@ components:
           type: string
         description:
           type: string
+          nullable: true
         color:
           type: number
           format: int16
@@ -2034,12 +2035,14 @@ components:
           $ref: "#/components/schemas/relativeTime"
         sortBy:
           type: string
+          nullable: true
           enum:
             - title
             - created_at
             - updated_at
         sortDirection:
           type: string
+          nullable: true
           enum:
             - ascending
             - descending
@@ -2098,6 +2101,7 @@ components:
       properties:
         unit:
           type: string
+          nullable: true
           enum:
             - "seconds"
             - "minutes"
@@ -2105,6 +2109,7 @@ components:
             - "days"
         value:
           type: number
+          nullable: true
           format: int64
   parameters:
     sortDirection:


### PR DESCRIPTION
# Description

views v2 introduces update-able optional fields, which we never had before on any `*_update` route. serde's json parsing does not (and cannot by default) differentiate between the absence of the field and it being explicitly set to `null` with an `Option` marked with `#[serde(default)]`.

this pr introduces a workaround by using a custom deserialize function. source: https://github.com/serde-rs/serde/issues/984#issuecomment-314143738

fixes FP-3079

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] ~~The changes have been tested to be backwards compatible.~~ **this is a breaking change**
- [x] The OpenAPI schema and generated client have been updated.
- [x] ~~New models module has been added to API generator script~~
- [x] PR for API is ready and reviewed: https://github.com/fiberplane/api/pull/628
- [x] ~~PR for Studio is ready and reviewed: (please link)~~
- [x] PR for CLI is ready and reviewed: https://github.com/fiberplane/fp/pull/233
- [x] ~~PR for FPD is ready and reviewed: (please link)~~
- [x] The CHANGELOG(s) are updated.

When adding new operation types:

- [x] ~~PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
