### PR TITLE
Fetch more history to be able to detect changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
       - name: setup-git-credentials
         uses: de-vri-es/setup-git-credentials@v2

--- a/fiberplane-ci/src/utils/git.rs
+++ b/fiberplane-ci/src/utils/git.rs
@@ -25,6 +25,7 @@ pub fn get_commits(repo_dir: &str) -> Result<Vec<String>> {
 
     output
         .split(|byte| byte == &b'\n')
+        .filter(|slice| !slice.is_empty())
         .map(|slice| {
             std::str::from_utf8(slice)
                 .map(str::to_owned)

--- a/xtask/src/commands/publish.rs
+++ b/xtask/src/commands/publish.rs
@@ -48,6 +48,14 @@ async fn handle_publish_alphas(args: &PublishArgs) -> TaskResult {
         .get(1)
         .context("Could not determine previous commit")?;
 
+    if args.all {
+        eprintln!("{NOTE}Will publish alpha versions for all publishable crates.");
+    } else {
+        eprintln!(
+            "{NOTE}Will publish alpha versions for all crates changed since {previous_commit}."
+        );
+    }
+
     let all_crate_dirs = get_publishable_workspace_crate_dirs(".")?;
     let crates_using_workspace_version = get_crates_using_workspace_version(".", &all_crate_dirs);
     let changed_crate_dirs: Vec<&str> = all_crate_dirs

--- a/xtask/src/constants.rs
+++ b/xtask/src/constants.rs
@@ -2,6 +2,7 @@ use console::Emoji;
 
 pub static CHECK: Emoji<'_, '_> = Emoji("✅ ", "");
 pub static ERROR: Emoji<'_, '_> = Emoji("🤒 ", "");
+pub static NOTE: Emoji<'_, '_> = Emoji("📝 ", "");
 pub static SUCCESS: Emoji<'_, '_> = Emoji("✨ ", "");
 pub static WARN: Emoji<'_, '_> = Emoji("⚠️ ", "");
 pub static WORKING: Emoji<'_, '_> = Emoji("🔧 ", "");


### PR DESCRIPTION
# Description

The [last workflow run](https://github.com/fiberplane/fiberplane/actions/runs/4427147947/jobs/7764340968) for publishing alphas returned:

```
fatal: bad revision ''
🤒 Error: Unexpected exit code (128) from `git diff`
```

I suspect this was because `actions/checkout` doesn't fetch any history by default, so I've bumped the fetch depth to 2. Also made a few small changes to improve the logging in case the issue was something else.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- ~~[ ] The changes have been tested to be backwards compatible.~~
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] New models module has been added to API generator script~~
- ~~[ ] PR for API is ready and reviewed: (please link)~~
- ~~[ ] PR for Studio is ready and reviewed: (please link)~~
- ~~[ ] PR for CLI is ready and reviewed: (please link)~~
- ~~[ ] PR for FPD is ready and reviewed: (please link)~~
- ~~[ ] The CHANGELOG(s) are updated.~~

When adding new operation types:

- ~~[ ] PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
