### PR TITLE
Adds Artifactory utils

### DIFF
--- a/fiberplane-ci/Cargo.toml
+++ b/fiberplane-ci/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 duct = "0.13"
 octocrab = { version = "0.18", default-features = false, features = ["rustls"] }
 reqwest = { version = "0.11", default-features = false, features = [
@@ -22,6 +22,7 @@ reqwest = { version = "0.11", default-features = false, features = [
     "multipart",
     "rustls-tls",
 ] }
+secrecy = { version = "0.8.0", features = ["serde", "bytes"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 taplo = "0.12"

--- a/fiberplane-ci/src/utils/artifactory.rs
+++ b/fiberplane-ci/src/utils/artifactory.rs
@@ -1,0 +1,118 @@
+use crate::utils::{parse_suffix, parse_version};
+use anyhow::{bail, Result};
+use clap::Parser;
+use reqwest::Client;
+use secrecy::ExposeSecret;
+use serde::Deserialize;
+
+pub const ARTIFACTORY_INDEX_URL: &str = "https://fiberplane.jfrog.io/artifactory";
+
+#[derive(Parser)]
+pub struct ArtifactoryCredentials {
+    /// API key configured in your Artifactory account.
+    #[clap(long, env)]
+    pub artifactory_token: secrecy::SecretString,
+
+    /// Email address you use to login to Artifactory.
+    #[clap(long, env)]
+    pub artifactory_username: String,
+}
+
+/// Determines the next applicable alpha version for a crate that is published
+/// to Artifactory.
+pub async fn determine_next_artifactory_alpha(
+    crate_name: &str,
+    base_version: &str,
+    credentials: &ArtifactoryCredentials,
+) -> Result<String> {
+    match get_previous_artifactory_alpha_version(crate_name, base_version, credentials).await? {
+        Some(version) => {
+            let (_major, _minor, _patch, Some(suffix)) = parse_version(&version)? else {
+                bail!("Expected alpha version has no suffix");
+            };
+            let (_suffix, count) = parse_suffix(suffix)?;
+            Ok(format!("{base_version}-alpha.{count}", count = count + 1))
+        }
+        None => Ok(format!("{base_version}-alpha.1")),
+    }
+}
+
+pub async fn get_previous_artifactory_alpha_version(
+    crate_name: &str,
+    base_version: &str,
+    credentials: &ArtifactoryCredentials,
+) -> Result<Option<String>> {
+    let prefix = format!("{crate_name}-");
+
+    let client = Client::new();
+    let response = client
+        .post(format!("{ARTIFACTORY_INDEX_URL}/api/search/aql"))
+        .basic_auth(
+            &credentials.artifactory_username,
+            Some(credentials.artifactory_token.expose_secret()),
+        )
+        .header("Content-Type", "text/plain")
+        .body(format!(
+            r#"items.find({{
+                "repo":"internal-cargo-local",
+                "path":"crates/{crate_name}",
+                "name":{{"$match":"{prefix}{base_version}-alpha.*"}}
+            }})
+            .include("repo","path","name")
+            .sort({{"$desc":["name"]}})"#
+        ))
+        .send()
+        .await?;
+    let response_text = response.text().await?;
+
+    let response: ArtifactorySearchResponse = serde_json::from_str(&response_text)?;
+    Ok(response.results.first().map(|result| {
+        let version = &result.name[prefix.len()..];
+        version.strip_suffix(".crate").unwrap_or(version).to_owned()
+    }))
+}
+
+/// Returns whether the given version of the given crate has been published to
+/// Artifactory.
+pub async fn is_published_to_artifactory(
+    crate_name: &str,
+    version: &str,
+    credentials: &ArtifactoryCredentials,
+) -> Result<bool> {
+    let client = Client::new();
+    let response = client
+        .post(format!("{ARTIFACTORY_INDEX_URL}/api/search/aql"))
+        .basic_auth(
+            &credentials.artifactory_username,
+            Some(credentials.artifactory_token.expose_secret()),
+        )
+        .header("Content-Type", "text/plain")
+        .body(format!(
+            r#"items.find({{
+                "repo":"internal-cargo-local",
+                "path":"crates/{crate_name}",
+                "name":"{crate_name}-{version}.crate"
+            }})
+            .include("repo","path","name")"#
+        ))
+        .send()
+        .await?;
+    let response_text = response.text().await?;
+
+    let response: ArtifactorySearchResponse = serde_json::from_str(&response_text)?;
+    Ok(response.results.first().is_some())
+}
+
+#[derive(Deserialize)]
+struct ArtifactorySearchResponse {
+    results: Vec<ArtifactorySearchResult>,
+}
+
+#[derive(Deserialize)]
+struct ArtifactorySearchResult {
+    #[allow(dead_code)]
+    repo: String,
+    #[allow(dead_code)]
+    path: String,
+    name: String,
+}

--- a/fiberplane-ci/src/utils/github.rs
+++ b/fiberplane-ci/src/utils/github.rs
@@ -55,13 +55,13 @@ impl WorkflowsExt for Octocrab {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 struct ListWorkflowRunsParams {
     event: String,
 }
 
 /// (Incomplete) representation of a Github Actions workflow run.
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct WorkflowRun {
     /// The ID of the workflow run.
     pub id: JobId,
@@ -111,7 +111,7 @@ pub struct WorkflowRun {
     pub run_started_at: Option<OffsetDateTime>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum WorkflowStatus {

--- a/fiberplane-ci/src/utils/mod.rs
+++ b/fiberplane-ci/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod artifactory;
 pub mod crates;
 pub mod git;
 pub mod github;
@@ -6,6 +7,7 @@ pub(crate) mod toml_patcher;
 pub mod versions;
 pub mod workspaces;
 
+pub use artifactory::*;
 pub use crates::*;
 pub use git::*;
 pub use github::*;

--- a/fiberplane-ci/src/utils/versions.rs
+++ b/fiberplane-ci/src/utils/versions.rs
@@ -71,8 +71,7 @@ pub fn matches_base_version(version: &str, base_version: &str) -> bool {
     }
 }
 
-/// Parses a version's alpha suffix into its count and the remainder of the
-/// suffix.
+/// Parses a version's suffix into its count and the remainder of the suffix.
 ///
 /// ```rust
 /// use fiberplane_ci::utils::parse_suffix;


### PR DESCRIPTION
# Description

Adds Artifactory utils to the `fiberplane-ci` crate. It's a little annoying it has to end up in our open-source repo while only benefiting closed crates, but there's nothing too private in there and it makes sense to keep it with the other CI tooling.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- ~~[ ] The changes have been tested to be backwards compatible.~~
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] New models module has been added to API generator script~~
- ~~[ ] PR for API is ready and reviewed: (please link)~~
- ~~[ ] PR for Studio is ready and reviewed: (please link)~~
- ~~[ ] PR for CLI is ready and reviewed: (please link)~~
- ~~[ ] PR for FPD is ready and reviewed: (please link)~~
- ~~[ ] The CHANGELOG(s) are updated.~~

When adding new operation types:

- ~~[ ] PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
