### PR TITLE
Add ArrayField variant in schema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ changes if the major version hasn't changed.
   to a new cell type and the data it expects. (#28)
 - `fiberplane-models`: Added `EventAddedMessage`, `EventUpdatedMessage`, `EventDeletedMessage`
   messages that can be sent to studio. (#28)
+- `fiberplane-models`: Added `ArrayField` variant of `QueryField` to specify provider
+  query schemas that include rows/records of arbitrary data. (#39)
 
 ### Changed
 

--- a/fiberplane-models/src/providers/schema/fields/array_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/array_field.rs
@@ -1,0 +1,137 @@
+use crate::providers::QuerySchema;
+#[cfg(feature = "fp-bindgen")]
+use fp_bindgen::prelude::Serializable;
+use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
+
+/// Defines an array of composite fields.
+///
+/// This is commonly used for arbitrarily long list of (key, value) pairs,
+/// or lists of (key, operator, value) filters.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
+#[cfg_attr(
+    feature = "fp-bindgen",
+    derive(Serializable),
+    fp(rust_module = "fiberplane_models::providers")
+)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct ArrayField {
+    /// Suggested label to display along the form field.
+    pub label: String,
+
+    /// Name of the field as it will be included in the encoded query or config
+    /// object.
+    pub name: String,
+    /// The minimum number of entries the array must have to be valid.
+    ///
+    /// Leaving the minimum_length to 0 makes the whole field optional.
+    #[builder(default = 0)]
+    pub minimum_length: u32,
+    /// The maximum number of entries the array can have and still be valid.
+    ///
+    /// It is None when there is no maximum number
+    #[builder(default, setter(strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maximum_length: Option<u32>,
+    /// The schema of the elements inside a row of the array.
+    ///
+    /// ### Accessing row fields
+    ///
+    /// The name of each QueryField inside the element_schema can be used as
+    /// an indexing key for a field. That means that if `element_schema` contains
+    /// a [TextField](crate::providers::TextField) with the name `parameter_name`,
+    /// then you will be able to access the value of that field using
+    /// `ArrayField::get(i)::get("parameter_name")` for the i-th element.
+    ///
+    /// ### Serialization
+    ///
+    /// For example if an array field has this `element_schema`:
+    /// ```rust,no_compile
+    /// ArrayField {
+    ///   name: "table".to_string(),
+    ///   element_schema: vec![
+    ///     TextField::new().with_name("key"),
+    ///     SelectField::new().with_name("operator").with_options(&["<", ">", "<=", ">=", "=="]),
+    ///     IntegerField::new().with_name("value"),
+    ///   ],
+    /// ..Default::default()
+    /// }
+    /// ```
+    ///
+    /// Then the URL-encoded serialization for the fields is expected to look like this
+    /// (line breaks are only kept for legibility):
+    /// ```txt
+    ///  "table[0][key]=less+than&
+    ///  table[2][operator]=%3E&
+    ///  table[0][operator]=%3C&
+    ///  table[2][key]=greater+than&
+    ///  table[2][value]=10&
+    ///  table[0][value]=12"
+    /// ```
+    ///
+    /// Note that we are allowed to skip indices, this serialization is expected to
+    /// be read as:
+    /// ```rust,no_compile
+    /// assert_eq!(table, vec![
+    ///   Row {
+    ///     key: "less than".to_string(),
+    ///     operator: "<".to_string(),
+    ///     value: 12,
+    ///   },
+    ///   Row {
+    ///     key: "greater than".to_string(),
+    ///     operator: ">".to_string(),
+    ///     value: 10,
+    ///   },
+    /// ])
+    /// ```
+    ///
+    /// ### Required row fields
+    ///
+    /// Any field that is marked as `required` inside `element_schema` makes it
+    /// mandatory to create a valid row to the Array Field.
+    pub element_schema: QuerySchema,
+}
+
+impl ArrayField {
+    /// Creates a new array field with all default values.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn with_label(self, label: &str) -> Self {
+        Self {
+            label: label.to_owned(),
+            ..self
+        }
+    }
+
+    pub fn with_element_schema(self, schema: QuerySchema) -> Self {
+        Self {
+            element_schema: schema,
+            ..self
+        }
+    }
+
+    pub fn with_name(self, name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            ..self
+        }
+    }
+
+    pub fn with_minimum_length(self, minimum_length: u32) -> Self {
+        Self {
+            minimum_length,
+            ..self
+        }
+    }
+
+    pub fn with_maximum_length(self, maximum_length: Option<u32>) -> Self {
+        Self {
+            maximum_length,
+            ..self
+        }
+    }
+}

--- a/fiberplane-models/src/providers/schema/fields/array_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/array_field.rs
@@ -2,13 +2,12 @@ use crate::providers::QuerySchema;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines an array of composite fields.
 ///
 /// This is commonly used for arbitrarily long list of (key, value) pairs,
 /// or lists of (key, operator, value) filters.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),
@@ -26,12 +25,10 @@ pub struct ArrayField {
     /// The minimum number of entries the array must have to be valid.
     ///
     /// Leaving the minimum_length to 0 makes the whole field optional.
-    #[builder(default = 0)]
     pub minimum_length: u32,
     /// The maximum number of entries the array can have and still be valid.
     ///
     /// It is None when there is no maximum number
-    #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub maximum_length: Option<u32>,
     /// The schema of the elements inside a row of the array.
@@ -49,17 +46,19 @@ pub struct ArrayField {
     /// For example if an array field has this `element_schema`:
     /// ```rust,no_run
     /// # use fiberplane_models::providers::{ArrayField, TextField, SelectField, IntegerField};
-    /// ArrayField::builder()
-    ///   .name("table".to_string())
-    ///   .label("example".to_string())
-    ///   .element_schema(vec![
+    /// ArrayField::new()
+    ///   .with_name("table")
+    ///   .with_label("example".to_string())
+    ///   .with_element_schema(vec![
     ///     TextField::new().with_name("key").into(),
     ///     SelectField::new().with_name("operator").with_options(&["<", ">", "<=", ">=", "=="]).into(),
     ///     IntegerField::new().with_name("value").into(),
-    ///   ]).build();
+    ///   ]);
     /// ```
     ///
-    /// Then the URL-encoded serialization for the fields is expected to look like this
+    /// Then the URL-encoded serialization for the fields is expected to use
+    /// the bracketed-notation. This means you _can_ encode all the
+    /// keys in the array in any order you want. It can look like this
     /// (line breaks are only kept for legibility):
     /// ```txt
     ///  "table[0][key]=less+than&
@@ -70,7 +69,18 @@ pub struct ArrayField {
     ///  table[0][value]=12"
     /// ```
     ///
-    /// Note that we are allowed to skip indices, this serialization is expected to
+    /// or you can do the "logic" ordering too:
+    /// ```txt
+    ///  "table[0][key]=less+than&
+    ///  table[0][operator]=%3C&
+    ///  table[0][value]=12&
+    ///  table[2][key]=greater+than&
+    ///  table[2][operator]=%3E&
+    ///  table[2][value]=10"
+    /// ```
+    ///
+    /// Note that we are allowed to skip indices.
+    /// Any of those 2 examples above will
     /// be read as:
     /// ```rust,no_run
     /// # #[derive(Debug, PartialEq)]
@@ -103,9 +113,9 @@ impl ArrayField {
         Default::default()
     }
 
-    pub fn with_label(self, label: &str) -> Self {
+    pub fn with_label<T: Into<String>>(self, label: T) -> Self {
         Self {
-            label: label.to_owned(),
+            label: label.into(),
             ..self
         }
     }
@@ -117,9 +127,9 @@ impl ArrayField {
         }
     }
 
-    pub fn with_name(self, name: &str) -> Self {
+    pub fn with_name<T: Into<String>>(self, name: T) -> Self {
         Self {
-            name: name.to_owned(),
+            name: name.into(),
             ..self
         }
     }
@@ -131,9 +141,9 @@ impl ArrayField {
         }
     }
 
-    pub fn with_maximum_length(self, maximum_length: Option<u32>) -> Self {
+    pub fn with_maximum_length(self, maximum_length: u32) -> Self {
         Self {
-            maximum_length,
+            maximum_length: Some(maximum_length),
             ..self
         }
     }

--- a/fiberplane-models/src/providers/schema/fields/array_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/array_field.rs
@@ -77,9 +77,9 @@ pub struct ArrayField {
     ///  "table[0][key]=less+than&
     ///  table[0][operator]=%3C&
     ///  table[0][value]=12&
-    ///  table[2][key]=greater+than&
-    ///  table[2][operator]=%3E&
-    ///  table[2][value]=10"
+    ///  table[1][key]=greater+than&
+    ///  table[1][operator]=%3E&
+    ///  table[1][value]=10"
     /// ```
     ///
     /// Note that we are allowed to skip indices.

--- a/fiberplane-models/src/providers/schema/fields/array_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/array_field.rs
@@ -47,16 +47,16 @@ pub struct ArrayField {
     /// ### Serialization
     ///
     /// For example if an array field has this `element_schema`:
-    /// ```rust,no_compile
-    /// ArrayField {
-    ///   name: "table".to_string(),
-    ///   element_schema: vec![
-    ///     TextField::new().with_name("key"),
-    ///     SelectField::new().with_name("operator").with_options(&["<", ">", "<=", ">=", "=="]),
-    ///     IntegerField::new().with_name("value"),
-    ///   ],
-    /// ..Default::default()
-    /// }
+    /// ```rust,no_run
+    /// # use fiberplane_models::providers::{ArrayField, TextField, SelectField, IntegerField};
+    /// ArrayField::builder()
+    ///   .name("table".to_string())
+    ///   .label("example".to_string())
+    ///   .element_schema(vec![
+    ///     TextField::new().with_name("key").into(),
+    ///     SelectField::new().with_name("operator").with_options(&["<", ">", "<=", ">=", "=="]).into(),
+    ///     IntegerField::new().with_name("value").into(),
+    ///   ]).build();
     /// ```
     ///
     /// Then the URL-encoded serialization for the fields is expected to look like this
@@ -72,7 +72,10 @@ pub struct ArrayField {
     ///
     /// Note that we are allowed to skip indices, this serialization is expected to
     /// be read as:
-    /// ```rust,no_compile
+    /// ```rust,no_run
+    /// # #[derive(Debug, PartialEq)]
+    /// # struct Row { key: String, operator: String, value: u32 }
+    /// # let table: Vec<Row> = vec![];
     /// assert_eq!(table, vec![
     ///   Row {
     ///     key: "less than".to_string(),
@@ -84,7 +87,7 @@ pub struct ArrayField {
     ///     operator: ">".to_string(),
     ///     value: 10,
     ///   },
-    /// ])
+    /// ]);
     /// ```
     ///
     /// ### Required row fields

--- a/fiberplane-models/src/providers/schema/fields/array_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/array_field.rs
@@ -116,7 +116,7 @@ impl ArrayField {
         Default::default()
     }
 
-    pub fn with_label<T: Into<String>>(self, label: T) -> Self {
+    pub fn with_label(self, label: impl Into<String>) -> Self {
         Self {
             label: label.into(),
             ..self
@@ -130,7 +130,7 @@ impl ArrayField {
         }
     }
 
-    pub fn with_name<T: Into<String>>(self, name: T) -> Self {
+    pub fn with_name(self, name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
             ..self

--- a/fiberplane-models/src/providers/schema/fields/array_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/array_field.rs
@@ -22,15 +22,18 @@ pub struct ArrayField {
     /// Name of the field as it will be included in the encoded query or config
     /// object.
     pub name: String,
+
     /// The minimum number of entries the array must have to be valid.
     ///
     /// Leaving the minimum_length to 0 makes the whole field optional.
     pub minimum_length: u32,
+
     /// The maximum number of entries the array can have and still be valid.
     ///
     /// It is None when there is no maximum number
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub maximum_length: Option<u32>,
+
     /// The schema of the elements inside a row of the array.
     ///
     /// ### Accessing row fields

--- a/fiberplane-models/src/providers/schema/fields/checkbox_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/checkbox_field.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a field that produces a boolean value.
 ///
@@ -9,7 +8,7 @@ use typed_builder::TypedBuilder;
 /// In the case of "application/x-www-form-urlencoded", it will be represented
 /// by the value defined in the `value` field, which will be either present or
 /// not, similar to the encoding of HTML forms.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/checkbox_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/checkbox_field.rs
@@ -9,7 +9,7 @@ use typed_builder::TypedBuilder;
 /// In the case of "application/x-www-form-urlencoded", it will be represented
 /// by the value defined in the `value` field, which will be either present or
 /// not, similar to the encoding of HTML forms.
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/date_time_range_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/date_time_range_field.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a field that produces two `DateTime` values, a "from" and a "to"
 /// value.
@@ -10,7 +9,7 @@ use typed_builder::TypedBuilder;
 /// `from` and `to` fields. In the case of "application/x-www-form-urlencoded",
 /// it will be represented as a single string and the "from" and "to" parts will
 /// be separated by a space.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/date_time_range_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/date_time_range_field.rs
@@ -10,7 +10,7 @@ use typed_builder::TypedBuilder;
 /// `from` and `to` fields. In the case of "application/x-www-form-urlencoded",
 /// it will be represented as a single string and the "from" and "to" parts will
 /// be separated by a space.
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/file_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/file_field.rs
@@ -1,12 +1,11 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a field that allows files to be uploaded as part of the query data.
 ///
 /// Query data that includes files will be encoded using "multipart/form-data".
-#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/file_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/file_field.rs
@@ -6,7 +6,7 @@ use typed_builder::TypedBuilder;
 /// Defines a field that allows files to be uploaded as part of the query data.
 ///
 /// Query data that includes files will be encoded using "multipart/form-data".
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/integer_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/integer_field.rs
@@ -1,10 +1,9 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a field that allows integer numbers to be entered.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/integer_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/integer_field.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
 /// Defines a field that allows integer numbers to be entered.
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/label_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/label_field.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a field that allows labels to be selected.
 ///
@@ -9,7 +8,7 @@ use typed_builder::TypedBuilder;
 /// array of strings, depending on the value of the `multiple` field. In the
 /// case of "application/x-www-form-urlencoded", the value is always a single
 /// string and multiple labels will be space-separated.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/label_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/label_field.rs
@@ -9,7 +9,7 @@ use typed_builder::TypedBuilder;
 /// array of strings, depending on the value of the `multiple` field. In the
 /// case of "application/x-www-form-urlencoded", the value is always a single
 /// string and multiple labels will be space-separated.
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/mod.rs
+++ b/fiberplane-models/src/providers/schema/fields/mod.rs
@@ -1,3 +1,4 @@
+mod array_field;
 mod checkbox_field;
 mod date_time_range_field;
 mod file_field;
@@ -6,6 +7,7 @@ mod label_field;
 mod select_field;
 mod text_field;
 
+pub use array_field::*;
 pub use checkbox_field::*;
 pub use date_time_range_field::*;
 pub use file_field::*;

--- a/fiberplane-models/src/providers/schema/fields/select_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/select_field.rs
@@ -7,7 +7,7 @@ use typed_builder::TypedBuilder;
 ///
 /// Values to be selected from can be either hard-coded in the schema, or
 /// (only for query forms) fetched on-demand the same way as auto-suggestions.
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/select_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/select_field.rs
@@ -1,13 +1,12 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a field that allows selection from a predefined list of options.
 ///
 /// Values to be selected from can be either hard-coded in the schema, or
 /// (only for query forms) fetched on-demand the same way as auto-suggestions.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/text_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/text_field.rs
@@ -6,7 +6,7 @@ use typed_builder::TypedBuilder;
 /// Defines a free-form text entry field.
 ///
 /// This is commonly used for filter text and query entry.
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/text_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/text_field.rs
@@ -1,12 +1,11 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a free-form text entry field.
 ///
 /// This is commonly used for filter text and query entry.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/query_schema.rs
+++ b/fiberplane-models/src/providers/schema/query_schema.rs
@@ -11,7 +11,7 @@ use super::fields::*;
 /// may be used.
 pub type QuerySchema = Vec<QueryField>;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),
@@ -27,6 +27,7 @@ pub enum QueryField {
     Integer(IntegerField),
     Select(SelectField),
     Text(TextField),
+    Array(ArrayField),
 }
 
 impl From<CheckboxField> for QueryField {
@@ -68,5 +69,11 @@ impl From<SelectField> for QueryField {
 impl From<TextField> for QueryField {
     fn from(field: TextField) -> Self {
         Self::Text(field)
+    }
+}
+
+impl From<ArrayField> for QueryField {
+    fn from(field: ArrayField) -> Self {
+        Self::Array(field)
     }
 }


### PR DESCRIPTION


# Description

Implements RFC-72 about composite fields in provider queries.

This boils down to adding a new variant of `QueryField` named `ArrayField`. Its main trait is that it nests a `QuerySchema` in its value, as `element_schema`, with the following semantics (extracted from the docstring)

## ArrayField::element_schema

The schema of the elements inside a row of the array.

### Accessing row fields

The name of each QueryField inside the element_schema can be used as
an indexing key for a field. That means that if `element_schema` contains
a [TextField](crate::providers::TextField) with the name `parameter_name`,
then you will be able to access the value of that field using
`ArrayField::get(i)::get("parameter_name")` for the i-th element.

### Serialization

For example if an array field has this `element_schema`:
```rust,no_compile
ArrayField {
  name: "table".to_string(),
  element_schema: vec![
    TextField::new().with_name("key"),
    SelectField::new().with_name("operator").with_options(&["<", ">", "<=", ">=", "=="]),
    IntegerField::new().with_name("value"),
  ],
..Default::default()
}
```

Then the URL-encoded serialization for the fields is expected to look like this
(line breaks are only kept for legibility):
```txt
 "table[0][key]=less+than&
 table[2][operator]=%3E&
 table[0][operator]=%3C&
 table[2][key]=greater+than&
 table[2][value]=10&
 table[0][value]=12"
```

Note that we are allowed to skip indices, this serialization is expected to
be read as:
```rust,no_compile
assert_eq!(table, vec![
  Row {
    key: "less than".to_string(),
    operator: "<".to_string(),
    value: 12,
  },
  Row {
    key: "greater than".to_string(),
    operator: ">".to_string(),
    value: 10,
  },
])
```

### Required row fields

Any field that is marked as `required` inside `element_schema` makes it
mandatory to create a valid row to the Array Field.

## Extras

Also derive `Clone, PartialEq` from the QueryField variants in order to manipulate those in dependent code and tests downstream

Fixes FP-2850

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [ ] The changes have been tested to be backwards compatible.
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] ~~New models module has been added to API generator script~~
- [x] ~~PR for API is ready and reviewed: (please link)~~
- [x] ~~PR for Studio is ready and reviewed: (please link)~~
- [x] ~~PR for CLI is ready and reviewed: (please link)~~
- [x] ~~PR for FPD is ready and reviewed: (please link)~~
- [ ] PR for providers is ready and reviewed: https://github.com/fiberplane/providers/pull/31
- [ ] The CHANGELOG(s) are updated.

When adding new operation types:

- [x] PR for fiberplane-ot is ready and reviewed: (please link)~~

After merging, please merge related PRs ASAP, so others don't get blocked.
