### PR TITLE
Type cleanup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,15 +13,17 @@ indicate they don't apply.
 
 - [ ] The changes have been tested to be backwards compatible.
 - [ ] The OpenAPI schema and generated client have been updated.
-- [ ] New models module has been added to API generator script
-- [ ] PR for API is ready and reviewed: (please link)
-- [ ] PR for Studio is ready and reviewed: (please link)
-- [ ] PR for CLI is ready and reviewed: (please link)
-- [ ] PR for FPD is ready and reviewed: (please link)
-- [ ] The CHANGELOG(s) are updated.
+- [ ] New models module has been added to API generator script.
+- [ ] New types/fields are well-documented and annotated.
+- [ ] The CHANGELOG is updated.
 
-When adding new operation types:
+> Please link any related PRs in other repositories that depend on this:
 
-- [ ] PR for fiberplane-ot is ready and reviewed: (please link)
+<!-- * API: https://github.com/fiberplane/api/pull/XXX -->
+<!-- * Studio: https://github.com/fiberplane/studio/pull/XXX  -->
+<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
+<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
+<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
+<!-- * OT: https://github.com/fiberplane/fiberplane-ot/pull/XXX -->
 
 After merging, please merge related PRs ASAP, so others don't get blocked.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ indicate they don't apply.
 - [ ] The changes have been tested to be backwards compatible.
 - [ ] The OpenAPI schema and generated client have been updated.
 - [ ] New models module has been added to API generator script.
-- [ ] New types/fields are well-documented and annotated.
+- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
 - [ ] The CHANGELOG is updated.
 
 > Please link any related PRs in other repositories that depend on this:

--- a/.github/workflows/check_jsonnet.yml
+++ b/.github/workflows/check_jsonnet.yml
@@ -37,11 +37,10 @@ jobs:
         fi
 
     - name: Verify template docs
-      working-directory: fiberplane-templates
       run: |
         scripts/generate_template_docs.sh
-        if ! git diff --quiet docs/template_api.md ; then
-          echo "::error file=docs/template_api.md::Out of date documentation, did you forgot to regenerate it?";
+        if ! git diff --quiet fiberplane-templates/docs/template_api.md ; then
+          echo "::error file=fiberplane-templates/docs/template_api.md::Out of date documentation, did you forgot to regenerate it?";
           git diff;
           exit 1;
         fi

--- a/.github/workflows/manual_publish.yml
+++ b/.github/workflows/manual_publish.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
       - name: setup-git-credentials
         uses: de-vri-es/setup-git-credentials@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,16 @@ changes if the major version hasn't changed.
 - `fiberplane-templates`: Well-known provider cells (`prometheus`, `loki`, `elasticsearch`)
   have their payloads converted to human-readable form when transformed into templates or
   snippets. (#34)
+- `fiberplane-models`: Changed many function signatures to be more consistent in
+  their usage of builders and how string arguments are accepted.
 
 ### Removed
 
 - Support for the legacy provider protocol has been removed.
 - `fiberplane-models`: The `PaginatedSearch` struct has been removed (#27)
+- Removed the `title` and associated `formatting` fields from `ProviderCell`.
+  The `title` argument for provider cells is still accepted in templates so as
+  not to break any existing templates.
 
 ## [v1.0.0-beta.1] - 2023-02-14
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,132 @@ token = "Bearer <TOKEN>"
    - If you receive a 500 error when trying to access the Artifactory registry,
      you probably used the correct token, but not the right username.
 
+## Adding types and their annotations
+
+Whenever adding types to this repository, please keep the following in mind:
+
+- Wherever feasible, public structs and enums must be `#[non_exhaustive]` to
+  give us the ability to extend them without breaking backwards compatibility.
+- In order to allow users to instantiate a `#[non_exhaustive]` struct, we must
+  provide some kind of constructor for them. We typically provide one of the
+  following two methods:
+
+  - We use an explicit, custom constructor by the name `new()` if such a
+    constructor would need few arguments who meaning would be immediately clear
+    from context.
+  - For other situations, we derive from `TypedBuilder` so that users can
+    conveniently call the setters they require, while the named setters will
+    help to document the meaning of each field being set. When using
+    `TypedBuilder`, please keep the following in mind:
+
+    - Fields that are not required for instantiation should be marked with
+      `#[builder(default)]`. These are usually fields wrapped in `Option`, but
+      they can be other types too if they have a sensible default. However, even
+      an `Option` field can be left without a default if it makes strong sense
+      for the type. For instance, if you want make sure users of the type don't
+      accidentally omit it.
+    - `Option` fields that marked as `#[builder(default)]` should have the
+      `#[builder(setter(strip_option))]` annotation too. This makes sure users
+      don't have to specify unnecessary `Some` wrappers.
+    - Fields with types that have common `Into` implementations should also be
+      marked with `#[builder(setter(into))]`. Examples are fields of type
+      `String`, `Base64Uuid` and `Timestamp`.
+
+  - Finally, structs with all optional fields may additionally derive `Default`.
+    This also allows users to create instances uses `Default::default()`, but
+    they will need to imperatively assign any fields they want to set.
+
+- For serialization, we consistently use the following annotation on `Option`
+  fields: `#[serde(default, skip_serialization_if = "Option::is_none")]`
+  The reason for this is that it saves serialization overhead, and also makes
+  the generated TypeScript a bit easier to use, because the types will be
+  converted to `field?: T` instead of `field: T | null`.
+
+  - Note that other types than `Option` may also skip serialization if it makes
+    sense for a given use case.
+
+- When adding a new field to an existing type, it must use both the
+  `#[builder(default)]` and `#[serde(default)]` annotations to avoid breaking
+  changes.
+
+- Removing a field or changing the type of an existing field is always a
+  breaking change. The same goes for removing a type.
+
+- Examples of fields with annotations:
+
+  ```rs
+  /// Field without special annotations. This makes sense, because the field
+  /// is required and has no obvious default value.
+  pub revision: u32;
+
+  /// Maximum amount of retries. Default value is 3.
+  #[builder(default = 3)]
+  pub max_retries: u32;
+
+  /// Field where all the annotations are combined. Note we use `setter(into)`
+  /// here because the stripped type is `String`, for which common `Into`
+  /// implementations are available.
+  #[builder(default, setter(into, strip_option))]
+  #[serde(default, skip_serialization_if = "Option::is_none")]
+  pub description: Option<String>;
+
+  /// Note that the previous example could be easily adjusted if the type
+  /// were not wrapped in `Option`.
+  #[builder(default, setter(into))]
+  #[serde(default, skip_serialization_if = "String::is_empty")]
+  pub description: String;
+  ```
+
+- Please add descriptive documentation to types and fields. What purpose does a
+  type serve? What is impact of setting a given field? Answering such questions
+  in the comments can provide valuable context.
+
+  - Note that Rust documentation comments start with a triple slash and support
+    limited Markdown. Double slashes are used for ordinary comments.
+
+- When adding new types, please derive the following traits whenever possible:
+  `Clone`, `Debug`, `Default`, `Deserialize`, `Eq`, `PartialEq`, `Serialize`,
+  `Serializable`.
+
+  - The `Serializable` trait comes from `fp-bindgen` and is added conditionally
+    using the following annotation:
+
+    ```rs
+    #[cfg_attr(
+        feature = "fp-bindgen",
+        derive(Serializable),
+        fp(rust_module = "<module_path>") // Set this to the path from where the type can be imported.
+    )]
+    ```
+
+## Adding methods
+
+When adding functions or methods, please take special care with defining
+argument types.
+
+- When taking ownership of an argument, prefer `impl Into<T>` for types that
+  have common `Into` implementations. Examples of such types are `String`,
+  `Base64Uuid` and `Timestamp`.
+- When only a reference to an argument is needed, consider using
+  `impl AsRef<T>`. This is mainly relevant for strings, where `impl AsRef<str>`
+  is preferred over either `String` or `&str`.
+
+The rationale for these suggestions is that they're both more ergonomic for the
+caller (they both allow passing `&str` and `String` as well as other types
+implementing the traits, such as `Cow<str>`), while also being composable with
+one another. For a complex function, this means you can even define a generic
+bound such as `T: AsRef<str> + Into<String>`, which still allows both types to
+be passed seamlessly, while being able to pass those arguments into other
+functions that accept either.
+
+For an example of where this is beneficial in practice, see
+`Cell::with_text_for_field()`. Depending on cell type, it needs to pass its
+`text` argument to either a method that wants references or a method that wants
+to take ownership.
+
+A more naive function could of course simply take `String` or `&str`, but it
+forces the conversion on the caller and may cause unnecessary allocations.
+
 ## TOML formatting
 
 We use the "Even Better TOML" VS Code extension for formatting `Cargo.toml`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,8 @@ Whenever adding types to this repository, please keep the following in mind:
   following two methods:
 
   - We use an explicit, custom constructor by the name `new()` if such a
-    constructor would need few arguments who meaning would be immediately clear
-    from context.
+    constructor would need few arguments whose meaning would be immediately
+    clear from context.
   - For other situations, we derive from `TypedBuilder` so that users can
     conveniently call the setters they require, while the named setters will
     help to document the meaning of each field being set. When using
@@ -58,8 +58,8 @@ Whenever adding types to this repository, please keep the following in mind:
       `#[builder(default)]`. These are usually fields wrapped in `Option`, but
       they can be other types too if they have a sensible default. However, even
       an `Option` field can be left without a default if it makes strong sense
-      for the type. For instance, if you want make sure users of the type don't
-      accidentally omit it.
+      for the type. For instance, if you want to make sure users of the type
+      don't accidentally omit it.
     - `Option` fields that marked as `#[builder(default)]` should have the
       `#[builder(setter(strip_option))]` annotation too. This makes sure users
       don't have to specify unnecessary `Some` wrappers.
@@ -68,7 +68,7 @@ Whenever adding types to this repository, please keep the following in mind:
       `String`, `Base64Uuid` and `Timestamp`.
 
   - Finally, structs with all optional fields may additionally derive `Default`.
-    This also allows users to create instances uses `Default::default()`, but
+    This also allows users to create instances using `Default::default()`, but
     they will need to imperatively assign any fields they want to set.
 
 - For serialization, we consistently use the following annotation on `Option`
@@ -81,8 +81,8 @@ Whenever adding types to this repository, please keep the following in mind:
     sense for a given use case.
 
 - When adding a new field to an existing type, it must use both the
-  `#[builder(default)]` and `#[serde(default)]` annotations to avoid breaking
-  changes.
+  `#[builder(default)]` and `#[serde(default, skip_serialization_if = "...")]`
+  annotations to avoid breaking changes.
 
 - Removing a field or changing the type of an existing field is always a
   breaking change. The same goes for removing a type.
@@ -113,8 +113,8 @@ Whenever adding types to this repository, please keep the following in mind:
   ```
 
 - Please add descriptive documentation to types and fields. What purpose does a
-  type serve? What is impact of setting a given field? Answering such questions
-  in the comments can provide valuable context.
+  type serve? What is the impact of setting a given field? Answering such
+  questions in the documentation can provide valuable context.
 
   - Note that Rust documentation comments start with a triple slash and support
     limited Markdown. Double slashes are used for ordinary comments.

--- a/fiberplane-api-client/Cargo.toml
+++ b/fiberplane-api-client/Cargo.toml
@@ -22,11 +22,6 @@ default-features = false
 features = ["derive"]
 version = "1"
 
-[dependencies.time]
-default-features = false
-features = ["formatting", "parsing", "serde-human-readable", "serde-well-known"]
-version = "0.3"
-
 [lib]
 crate-type = ["rlib"]
 edition = "2021"

--- a/fiberplane-api-client/src/lib.rs
+++ b/fiberplane-api-client/src/lib.rs
@@ -6,8 +6,6 @@
 use crate::clients::ApiClient;
 use anyhow::{Context as _, Result};
 use reqwest::Method;
-use time::format_description::well_known::Rfc3339;
-
 pub mod builder;
 pub mod clients;
 
@@ -891,8 +889,8 @@ pub async fn data_source_update(
 pub async fn event_list(
     client: &ApiClient,
     workspace_id: base64uuid::Base64Uuid,
-    occurrence_time_start: time::OffsetDateTime,
-    occurrence_time_end: time::OffsetDateTime,
+    occurrence_time_start: fiberplane_models::timestamps::Timestamp,
+    occurrence_time_end: fiberplane_models::timestamps::Timestamp,
     labels: Option<std::collections::HashMap<String, String>>,
     sort_by: Option<&str>,
     sort_direction: Option<&str>,
@@ -906,11 +904,8 @@ pub async fn event_list(
             workspace_id = workspace_id,
         ),
     )?;
-    builder = builder.query(&[(
-        "occurrence_time_start",
-        occurrence_time_start.format(&Rfc3339)?,
-    )]);
-    builder = builder.query(&[("occurrence_time_end", occurrence_time_end.format(&Rfc3339)?)]);
+    builder = builder.query(&[("occurrence_time_start", occurrence_time_start.to_string())]);
+    builder = builder.query(&[("occurrence_time_end", occurrence_time_end.to_string())]);
     if let Some(labels) = labels {
         builder = builder.query(&[("labels", serde_json::to_string(&labels)?)]);
     }

--- a/fiberplane-markdown/src/from_markdown/mod.rs
+++ b/fiberplane-markdown/src/from_markdown/mod.rs
@@ -60,9 +60,7 @@ impl<'a> MarkdownConverter<'a> {
         NewNotebook::builder()
             .title(self.parse_title())
             .cells(self.parse_cells())
-            .time_range(NewTimeRange::Relative(
-                RelativeTimeRange::builder().minutes(-60).build(),
-            ))
+            .time_range(NewTimeRange::Relative(RelativeTimeRange::from_minutes(-60)))
             .build()
     }
 

--- a/fiberplane-markdown/src/to_markdown/mod.rs
+++ b/fiberplane-markdown/src/to_markdown/mod.rs
@@ -125,12 +125,6 @@ impl<'a> NotebookConverter<'a> {
                     self.end_all_lists();
                 }
                 Cell::Provider(cell) => {
-                    if !cell.title.is_empty() {
-                        self.events.push(Start(Tag::Paragraph));
-                        self.convert_formatted_text(cell.title, cell.formatting);
-                        self.events.push(End(Tag::Paragraph));
-                    }
-
                     if let Some(output) = cell.output {
                         self.convert_cells(output);
                     }

--- a/fiberplane-markdown/src/to_markdown/mod.rs
+++ b/fiberplane-markdown/src/to_markdown/mod.rs
@@ -4,7 +4,6 @@ use pulldown_cmark::Event::{self, *};
 use pulldown_cmark::{CodeBlockKind, CowStr, HeadingLevel, LinkType, Tag};
 use pulldown_cmark_to_cmark::{cmark_with_options, Options};
 use std::cmp::Ordering;
-use time::format_description::well_known::Rfc3339;
 use tracing::warn;
 
 #[cfg(test)]
@@ -269,9 +268,7 @@ impl<'a> NotebookConverter<'a> {
                 // Timestamps are turned into bold text and formatted as RFC-3339
                 Annotation::Timestamp { timestamp } => {
                     self.events.push(Start(Tag::Strong));
-                    let formatted = timestamp
-                        .format(&Rfc3339)
-                        .expect("Could not format timestamp as RFC-3339");
+                    let formatted = timestamp.to_string();
                     let length = formatted.chars().count();
                     current_offset += length;
                     self.text(content.take(length).collect::<String>());

--- a/fiberplane-markdown/src/to_markdown/tests.rs
+++ b/fiberplane-markdown/src/to_markdown/tests.rs
@@ -1,8 +1,7 @@
 use super::*;
-use fiberplane_models::formatting::Annotation::Timestamp;
 use fiberplane_models::formatting::{Annotation, AnnotationWithOffset, Formatting, Mention};
 use fiberplane_models::notebooks::*;
-use time::OffsetDateTime;
+use fiberplane_models::timestamps::Timestamp;
 
 #[test]
 fn title() {
@@ -94,8 +93,8 @@ fn timestamps() {
         "Some 2020-01-01T00:00:00Z timestamp".to_string(),
         vec![AnnotationWithOffset::new(
             5,
-            Timestamp {
-                timestamp: OffsetDateTime::parse("2020-01-01T00:00:00Z", &Rfc3339).unwrap(),
+            Annotation::Timestamp {
+                timestamp: Timestamp::parse("2020-01-01T00:00:00Z").unwrap(),
             },
         )],
     );

--- a/fiberplane-models/src/comments.rs
+++ b/fiberplane-models/src/comments.rs
@@ -1,4 +1,4 @@
-use crate::formatting::Formatting;
+use crate::{formatting::Formatting, timestamps::Timestamp};
 use base64uuid::Base64Uuid;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
@@ -15,15 +15,19 @@ use typed_builder::TypedBuilder;
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Thread {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
     #[builder(default)]
     pub items: Vec<ThreadItem>,
     pub status: ThreadStatus,
     pub created_by: UserSummary,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
+
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
+
+    #[builder(setter(into))]
+    pub updated_at: Timestamp,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -48,18 +52,28 @@ pub enum ThreadStatus {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadSummary {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
     pub item_count: u32,
+
+    #[builder(default, setter(strip_option))]
     pub first_item: Option<ThreadItem>,
+
     /// These are sorted in chronological order so the last one is the most recent.
+    #[builder(default)]
     #[serde(default)]
     pub recent_items: Vec<ThreadItem>,
+
     pub status: ThreadStatus,
+
     pub created_by: UserSummary,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
+
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
+
+    #[builder(setter(into))]
+    pub updated_at: Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -103,11 +117,15 @@ impl ThreadItem {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadStatusChange {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
     pub status: ThreadStatus,
+
     pub created_by: UserSummary,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
+
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
@@ -119,13 +137,17 @@ pub struct ThreadStatusChange {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct CommentDelete {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
     pub created_by: UserSummary,
-    /// Timestamp when the original comment was created
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub deleted_at: OffsetDateTime,
+
+    /// Timestamp when the original comment was created.
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
+
+    #[builder(setter(into))]
+    pub deleted_at: Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
@@ -137,18 +159,22 @@ pub struct CommentDelete {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Comment {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
     pub created_by: UserSummary,
+
     #[builder(setter(into))]
     pub content: String, // limit of 2048 characters
+
     #[builder(default)]
     pub formatting: Formatting,
+
     #[builder(setter(into))]
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
+    pub created_at: Timestamp,
+
     #[builder(setter(into))]
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
@@ -162,6 +188,7 @@ pub struct Comment {
 pub struct UserSummary {
     #[builder(setter(into))]
     pub id: String,
+
     #[builder(setter(into))]
     pub name: String,
 }
@@ -177,8 +204,10 @@ pub struct UserSummary {
 pub struct NewComment {
     #[builder(default, setter(into, strip_option))]
     pub id: Option<Base64Uuid>,
+
     #[builder(setter(into))]
     pub content: String,
+
     #[builder(default)]
     #[serde(default)]
     pub formatting: Formatting,
@@ -195,6 +224,7 @@ pub struct NewComment {
 pub struct UpdateComment {
     #[builder(setter(into))]
     pub content: String,
+
     #[builder(default)]
     #[serde(default)]
     pub formatting: Formatting,
@@ -209,10 +239,12 @@ pub struct UpdateComment {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct NewThread {
-    #[builder(default, setter(strip_option))]
+    #[builder(default, setter(into, strip_option))]
     pub id: Option<Base64Uuid>,
-    #[builder(default, setter(strip_option))]
+
+    #[builder(default, setter(into, strip_option))]
     pub referenced_cell_id: Option<Base64Uuid>,
+
     #[builder(default, setter(strip_option))]
     pub comment: Option<NewComment>,
 }

--- a/fiberplane-models/src/data_sources.rs
+++ b/fiberplane-models/src/data_sources.rs
@@ -1,4 +1,4 @@
-use crate::{names::Name, providers::Error};
+use crate::{names::Name, providers::Error, timestamps::Timestamp};
 use base64uuid::Base64Uuid;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
@@ -6,36 +6,61 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 use strum_macros::Display;
-use time::{serde::rfc3339, OffsetDateTime};
 use typed_builder::TypedBuilder;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TypedBuilder)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct DataSource {
-    pub name: Name,
-    #[builder(default)]
-    pub proxy_name: Option<Name>,
+    /// Data source ID.
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
+    /// Name of the data source.
+    ///
+    /// Data source names do not need to be unique per workspace, but they are
+    /// unique per proxy.
+    pub name: Name,
+
+    /// Optional name of the FPD instance through which requests to the data
+    /// source should be proxied. This is `None` for direct data sources.
+    #[builder(default, setter(strip_option))]
+    pub proxy_name: Option<Name>,
+
+    /// The type of provider used for querying the data source.
+    #[builder(setter(into))]
     pub provider_type: String,
+
+    /// Protocol version supported by the provider.
     #[builder(default)]
     #[serde(default)]
     pub protocol_version: u8,
-    #[builder(default)]
+
+    /// Optional human-friendly description of the data source.
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[builder(default)]
+
+    /// Optional configuration for the data source. If the data source is
+    /// proxied through an FPD instance, the config will not be exposed to
+    /// outside clients.
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config: Option<Map<String, Value>>,
-    #[builder(default)]
+
+    /// The data source status as reported by the FPD instance. Will be `None`
+    /// for direct data sources.
+    #[builder(default, setter(strip_option))]
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub status: Option<DataSourceStatus>,
+
+    /// Timestamp at which the data source was created.
     #[builder(setter(into))]
-    #[serde(with = "rfc3339")]
-    pub created_at: OffsetDateTime,
+    pub created_at: Timestamp,
+
+    /// Timestamp at which the data source or its config was last updated.
     #[builder(setter(into))]
-    #[serde(with = "rfc3339")]
-    pub updated_at: OffsetDateTime,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Display)]
@@ -56,13 +81,16 @@ pub enum DataSourceStatus {
 #[serde(rename_all = "camelCase")]
 pub struct NewDataSource {
     pub name: Name,
+
     #[builder(setter(into))]
     pub provider_type: String,
-    #[builder(default)]
+
     #[serde(default)]
     pub protocol_version: u8,
-    #[builder(default, setter(into))]
+
+    #[builder(default, setter(into, strip_option))]
     pub description: Option<String>,
+
     #[builder(default, setter(into))]
     pub config: Map<String, Value>,
 }
@@ -71,7 +99,10 @@ pub struct NewDataSource {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateDataSource {
+    #[builder(default, setter(into, strip_option))]
     pub description: Option<String>,
+
+    #[builder(default, setter(into, strip_option))]
     pub config: Option<Map<String, Value>>,
 }
 

--- a/fiberplane-models/src/data_sources.rs
+++ b/fiberplane-models/src/data_sources.rs
@@ -95,7 +95,7 @@ pub struct NewDataSource {
     pub config: Map<String, Value>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, TypedBuilder)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, TypedBuilder)]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateDataSource {

--- a/fiberplane-models/src/events.rs
+++ b/fiberplane-models/src/events.rs
@@ -1,9 +1,9 @@
+use crate::timestamps::Timestamp;
 use base64uuid::Base64Uuid;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use time::OffsetDateTime;
 use typed_builder::TypedBuilder;
 
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize, Debug, TypedBuilder)]
@@ -15,23 +15,27 @@ use typed_builder::TypedBuilder;
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Event {
-    /// Unique identifier associated with this event
+    /// Unique identifier associated with this event.
+    #[builder(setter(into))]
     pub id: Base64Uuid,
 
-    /// The title describing the event
+    /// The title describing the event.
+    #[builder(setter(into))]
     pub title: String,
 
-    /// Labels associated with the event
+    /// Labels associated with the event.
+    #[builder(default, setter(into))]
     pub labels: HashMap<String, Option<String>>,
 
-    /// The moment the event occurred
-    #[serde(with = "time::serde::rfc3339")]
-    pub occurrence_time: OffsetDateTime,
+    /// The moment the event occurred.
+    #[builder(setter(into))]
+    pub occurrence_time: Timestamp,
 
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
+
+    #[builder(setter(into))]
+    pub updated_at: Timestamp,
 }
 
 #[derive(Clone, Default, Deserialize, Eq, PartialEq, Serialize, Debug, TypedBuilder)]
@@ -50,7 +54,6 @@ pub struct NewEvent {
     #[serde(default)]
     pub labels: Option<HashMap<String, Option<String>>>,
 
-    #[builder(default, setter(into))]
-    #[serde(default, with = "time::serde::rfc3339::option")]
-    pub time: Option<OffsetDateTime>,
+    #[builder(default, setter(into, strip_option))]
+    pub time: Option<Timestamp>,
 }

--- a/fiberplane-models/src/events.rs
+++ b/fiberplane-models/src/events.rs
@@ -55,5 +55,6 @@ pub struct NewEvent {
     pub labels: Option<HashMap<String, Option<String>>>,
 
     #[builder(default, setter(into, strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub time: Option<Timestamp>,
 }

--- a/fiberplane-models/src/labels.rs
+++ b/fiberplane-models/src/labels.rs
@@ -3,14 +3,13 @@ use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 use thiserror::Error;
-use typed_builder::TypedBuilder;
 
 const MAX_LABEL_VALUE_LENGTH: usize = 63;
 const MAX_LABEL_NAME_LENGTH: usize = 63;
 const MAX_LABEL_PREFIX_LENGTH: usize = 253;
 
 /// Labels that are associated with a Notebook.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/notebooks/cells.rs
+++ b/fiberplane-models/src/notebooks/cells.rs
@@ -62,12 +62,12 @@ impl Cell {
             | Cell::Graph(_)
             | Cell::Image(_)
             | Cell::Log(_)
+            | Cell::Provider(_)
             | Cell::Table(_)
             | Cell::Timeline(_) => None,
             Cell::Checkbox(cell) => Some(&cell.formatting),
             Cell::Heading(cell) => Some(&cell.formatting),
             Cell::ListItem(cell) => Some(&cell.formatting),
-            Cell::Provider(cell) => Some(&cell.formatting),
             Cell::Text(cell) => Some(&cell.formatting),
         }
     }
@@ -111,10 +111,7 @@ impl Cell {
 
     /// Returns the cell's text, if any.
     pub fn text(&self) -> Option<&str> {
-        match self {
-            Cell::Provider(cell) => Some(&cell.title),
-            cell => cell.content(),
-        }
+        self.content()
     }
 
     /// Returns a copy of the cell with a new ID.
@@ -210,16 +207,7 @@ impl Cell {
                 ..*cell
             }),
             Cell::Log(cell) => Cell::Log(cell.clone()),
-            Cell::Provider(cell) => Cell::Provider(ProviderCell {
-                id: cell.id.clone(),
-                formatting: Formatting::default(),
-                intent: cell.intent.clone(),
-                output: cell.output.clone(),
-                query_data: cell.query_data.clone(),
-                read_only: cell.read_only,
-                response: cell.response.clone(),
-                title: text.to_owned(),
-            }),
+            Cell::Provider(cell) => Cell::Provider(cell.clone()),
             Cell::Table(cell) => Cell::Table(cell.clone()),
             Cell::Text(cell) => Cell::Text(TextCell {
                 id: cell.id.clone(),
@@ -267,16 +255,6 @@ impl Cell {
                 formatting,
                 ..*cell
             }),
-            Cell::Provider(cell) => Cell::Provider(ProviderCell {
-                id: cell.id.clone(),
-                formatting,
-                intent: cell.intent.clone(),
-                output: cell.output.clone(),
-                query_data: cell.query_data.clone(),
-                read_only: cell.read_only,
-                response: cell.response.clone(),
-                title: text.to_owned(),
-            }),
             Cell::Text(cell) => Cell::Text(TextCell {
                 id: cell.id.clone(),
                 content: text.to_owned(),
@@ -288,6 +266,7 @@ impl Cell {
             | Cell::Divider(_)
             | Cell::Graph(_)
             | Cell::Image(_)
+            | Cell::Provider(_)
             | Cell::Table(_)
             | Cell::Timeline(_) => self.with_text(text),
         }
@@ -348,7 +327,6 @@ impl Cell {
             Cell::Checkbox(cell) => Some(&mut cell.formatting),
             Cell::Heading(cell) => Some(&mut cell.formatting),
             Cell::ListItem(cell) => Some(&mut cell.formatting),
-            Cell::Provider(cell) => Some(&mut cell.formatting),
             Cell::Text(cell) => Some(&mut cell.formatting),
             Cell::Code(_)
             | Cell::Discussion(_)
@@ -356,6 +334,7 @@ impl Cell {
             | Cell::Graph(_)
             | Cell::Image(_)
             | Cell::Log(_)
+            | Cell::Provider(_)
             | Cell::Table(_)
             | Cell::Timeline(_) => None,
         }
@@ -373,7 +352,7 @@ impl Cell {
             Cell::Heading(cell) => Some(&mut cell.content),
             Cell::ListItem(cell) => Some(&mut cell.content),
             Cell::Log(_) => None,
-            Cell::Provider(cell) => Some(&mut cell.title),
+            Cell::Provider(_) => None,
             Cell::Table(_) => None,
             Cell::Text(cell) => Some(&mut cell.content),
             Cell::Timeline(_) => None,
@@ -411,19 +390,24 @@ impl Cell {
 pub struct CheckboxCell {
     #[builder(default, setter(into))]
     pub id: String,
+
     #[builder(default)]
     pub checked: bool,
+
     #[builder(default, setter(into))]
     pub content: String,
+
     /// Optional formatting to be applied to the cell's content.
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Formatting::is_empty")]
     pub formatting: Formatting,
+
     #[builder(default, setter(strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub level: Option<u8>,
+
     #[builder(default, setter(strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
 }
 
@@ -438,14 +422,17 @@ pub struct CheckboxCell {
 pub struct CodeCell {
     #[builder(default, setter(into))]
     pub id: String,
-    #[builder(setter(into))]
+
+    #[builder(default, setter(into))]
     pub content: String,
+
     #[builder(default, setter(strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
+
     /// Optional MIME type to use for syntax highlighting.
-    #[builder(default, setter(strip_option, into))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(into, strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub syntax: Option<String>,
 }
 
@@ -458,11 +445,11 @@ pub struct CodeCell {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct DividerCell {
-    #[builder(setter(into))]
+    #[builder(default, setter(into))]
     pub id: String,
 
     #[builder(default, setter(strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
 }
 
@@ -475,7 +462,7 @@ pub struct DividerCell {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct GraphCell {
-    #[builder(setter(into))]
+    #[builder(default, setter(into))]
     pub id: String,
 
     /// Links to the data to render in the graph.
@@ -486,7 +473,7 @@ pub struct GraphCell {
     pub graph_type: GraphType,
 
     #[builder(default, setter(strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
 
     #[builder(default)]
@@ -504,13 +491,17 @@ pub struct GraphCell {
 pub struct HeadingCell {
     #[builder(default, setter(into))]
     pub id: String,
+
     pub heading_type: HeadingType,
+
     #[builder(default, setter(into))]
     pub content: String,
+
     /// Optional formatting to be applied to the cell's content.
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Formatting::is_empty")]
     pub formatting: Formatting,
+
     #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
@@ -525,7 +516,7 @@ pub struct HeadingCell {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct LogCell {
-    #[builder(setter(into))]
+    #[builder(default, setter(into))]
     pub id: String,
 
     /// Links to the data to render in the log.
@@ -605,20 +596,26 @@ pub struct LogRecordIndex {
 pub struct ListItemCell {
     #[builder(default, setter(into))]
     pub id: String,
+
     #[builder(default, setter(into))]
     pub content: String,
+
     /// Optional formatting to be applied to the cell's content.
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Formatting::is_empty")]
     pub formatting: Formatting,
+
     #[builder(default)]
     pub list_type: ListType,
+
     #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub level: Option<u8>,
+
     #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
+
     #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub start_number: Option<u16>,
@@ -633,7 +630,7 @@ pub struct ListItemCell {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderCell {
-    #[builder(setter(into))]
+    #[builder(default, setter(into))]
     pub id: String,
 
     /// The intent served by this provider cell.
@@ -648,7 +645,7 @@ pub struct ProviderCell {
     ///
     /// Note: The format follows the specification for data URLs, without the
     ///       `data:` prefix. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
-    #[builder(default, setter(strip_option, into))]
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub query_data: Option<String>,
 
@@ -661,16 +658,6 @@ pub struct ProviderCell {
     #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output: Option<Vec<Cell>>,
-
-    /// Optional title to assign the cell.
-    #[builder(default, setter(into))]
-    #[serde(default)]
-    pub title: String,
-
-    /// Optional formatting to apply to the title.
-    #[builder(default)]
-    #[serde(default, skip_serializing_if = "Formatting::is_empty")]
-    pub formatting: Formatting,
 
     #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -771,12 +758,15 @@ pub enum TableCellValue {
 pub struct TextCell {
     #[builder(default, setter(into))]
     pub id: String,
+
     #[builder(default, setter(into))]
     pub content: String,
+
     /// Optional formatting to be applied to the cell's content.
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Formatting::is_empty")]
     pub formatting: Formatting,
+
     #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
@@ -790,6 +780,7 @@ pub struct TextCell {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct TimelineCell {
+    #[builder(default, setter(into))]
     pub id: String,
 
     /// Links to the data to render in the timeline.
@@ -815,7 +806,7 @@ pub struct ImageCell {
     pub id: String,
 
     // Refers to the id for a file (used to retrieve the file)
-    #[builder(default, setter(strip_option, into))]
+    #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_id: Option<String>,
 
@@ -826,6 +817,7 @@ pub struct ImageCell {
     #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub progress: Option<f64>,
+
     #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
@@ -833,19 +825,20 @@ pub struct ImageCell {
     #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<i32>,
+
     #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<i32>,
 
     /// Will contain a hash to show as a preview for the image
-    #[builder(default, setter(strip_option, into))]
+    #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preview: Option<String>,
 
     /// URL of the image if it was originally hosted on a remote server.
     /// This will not be set if the image was uploaded through the
     /// Fiberplane Studio.
-    #[builder(default, setter(strip_option, into))]
+    #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }
@@ -861,8 +854,10 @@ pub struct ImageCell {
 pub struct DiscussionCell {
     #[builder(default, setter(into))]
     pub id: String,
+
     #[builder(default, setter(into))]
     pub thread_id: String,
+
     #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,

--- a/fiberplane-models/src/notebooks/cells.rs
+++ b/fiberplane-models/src/notebooks/cells.rs
@@ -176,17 +176,17 @@ impl Cell {
     /// Returns a copy of the cell with its text replaced by the given text,
     /// without any formatting.
     #[must_use]
-    pub fn with_text(&self, text: &str) -> Self {
+    pub fn with_text(&self, text: impl Into<String>) -> Self {
         match self {
             Cell::Checkbox(cell) => Cell::Checkbox(CheckboxCell {
                 id: cell.id.clone(),
-                content: text.to_owned(),
+                content: text.into(),
                 formatting: Formatting::default(),
                 ..*cell
             }),
             Cell::Code(cell) => Cell::Code(CodeCell {
                 id: cell.id.clone(),
-                content: text.to_owned(),
+                content: text.into(),
                 syntax: cell.syntax.clone(),
                 ..*cell
             }),
@@ -195,14 +195,14 @@ impl Cell {
             Cell::Graph(cell) => Cell::Graph(cell.clone()),
             Cell::Heading(cell) => Cell::Heading(HeadingCell {
                 id: cell.id.clone(),
-                content: text.to_owned(),
+                content: text.into(),
                 formatting: Formatting::default(),
                 ..*cell
             }),
             Cell::Image(cell) => Cell::Image(cell.clone()),
             Cell::ListItem(cell) => Cell::ListItem(ListItemCell {
                 id: cell.id.clone(),
-                content: text.to_owned(),
+                content: text.into(),
                 formatting: Formatting::default(),
                 ..*cell
             }),
@@ -211,7 +211,7 @@ impl Cell {
             Cell::Table(cell) => Cell::Table(cell.clone()),
             Cell::Text(cell) => Cell::Text(TextCell {
                 id: cell.id.clone(),
-                content: text.to_owned(),
+                content: text.into(),
                 formatting: Formatting::default(),
                 ..*cell
             }),
@@ -225,39 +225,29 @@ impl Cell {
     /// **Warning:** For cell types that have text, but which do not support
     ///              rich-text, the formatting will be dropped silently.
     #[must_use]
-    pub fn with_rich_text(&self, text: &str, formatting: Formatting) -> Self {
+    pub fn with_rich_text(&self, text: impl Into<String>, formatting: Formatting) -> Self {
         match self {
             Cell::Checkbox(cell) => Cell::Checkbox(CheckboxCell {
                 id: cell.id.clone(),
-                content: text.to_owned(),
+                content: text.into(),
                 formatting,
-                ..*cell
-            }),
-            Cell::Log(cell) => Cell::Log(LogCell {
-                id: cell.id.clone(),
-                data_links: cell.data_links.clone(),
-                display_fields: cell.display_fields.clone(),
-                expanded_indices: cell.expanded_indices.clone(),
-                selected_indices: cell.selected_indices.clone(),
-                highlighted_indices: cell.highlighted_indices.clone(),
-                visibility_filter: cell.visibility_filter.clone(),
                 ..*cell
             }),
             Cell::Heading(cell) => Cell::Heading(HeadingCell {
                 id: cell.id.clone(),
-                content: text.to_owned(),
+                content: text.into(),
                 formatting,
                 ..*cell
             }),
             Cell::ListItem(cell) => Cell::ListItem(ListItemCell {
                 id: cell.id.clone(),
-                content: text.to_owned(),
+                content: text.into(),
                 formatting,
                 ..*cell
             }),
             Cell::Text(cell) => Cell::Text(TextCell {
                 id: cell.id.clone(),
-                content: text.to_owned(),
+                content: text.into(),
                 formatting,
                 ..*cell
             }),
@@ -266,6 +256,7 @@ impl Cell {
             | Cell::Divider(_)
             | Cell::Graph(_)
             | Cell::Image(_)
+            | Cell::Log(_)
             | Cell::Provider(_)
             | Cell::Table(_)
             | Cell::Timeline(_) => self.with_text(text),
@@ -282,15 +273,18 @@ impl Cell {
     /// **Warning:** For cell types that have text, but which do not support
     ///              rich-text, any given formatting will be dropped silently.
     #[must_use]
-    pub fn with_text_for_field(
+    pub fn with_text_for_field<T>(
         &self,
-        text: &str,
+        text: T,
         formatting: Option<Formatting>,
-        field: Option<&str>,
-    ) -> Self {
+        field: Option<impl AsRef<str>>,
+    ) -> Self
+    where
+        T: Into<String> + AsRef<str>,
+    {
         match (self, field) {
             (Cell::Provider(cell), Some(field)) => {
-                Cell::Provider(cell.with_query_field(field, text))
+                Cell::Provider(cell.with_query_field(field.as_ref(), text))
             }
             (cell, _) => {
                 if let Some(formatting) = formatting {
@@ -669,9 +663,9 @@ impl ProviderCell {
     /// the given query field.
     ///
     /// Unsets the query field if the value is empty.
-    pub fn with_query_field(&self, field_name: &str, value: &str) -> Self {
+    pub fn with_query_field(&self, field_name: impl AsRef<str>, value: impl AsRef<str>) -> Self {
         let query_data = self.query_data.as_deref().unwrap_or_default();
-        let query_data = if value.is_empty() {
+        let query_data = if value.as_ref().is_empty() {
             unset_query_field(query_data, field_name)
         } else {
             set_query_field(query_data, field_name, value)

--- a/fiberplane-models/src/notebooks/mod.rs
+++ b/fiberplane-models/src/notebooks/mod.rs
@@ -375,7 +375,7 @@ impl NewTemplate {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize, TypedBuilder)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/notebooks/mod.rs
+++ b/fiberplane-models/src/notebooks/mod.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 use strum_macros::Display;
-use time::OffsetDateTime;
 use typed_builder::TypedBuilder;
 use url::Url;
 
@@ -36,21 +35,32 @@ pub type FrontMatter = Map<String, Value>;
 pub struct Notebook {
     #[builder(default, setter(into))]
     pub id: String,
-    #[builder(default)]
+
+    #[builder(default, setter(into))]
     pub workspace_id: Base64Uuid,
+
     #[builder(setter(into))]
     pub created_at: Timestamp,
+
     #[builder(setter(into))]
     pub updated_at: Timestamp,
+
     pub time_range: TimeRange,
+
     #[builder(default, setter(into))]
     pub title: String,
+
     #[builder(default)]
     pub cells: Vec<Cell>,
+
     pub revision: u32,
+
+    #[builder(default)]
     pub visibility: NotebookVisibility,
+
     #[builder(default)]
     pub read_only: bool,
+
     pub created_by: CreatedBy,
 
     #[builder(default)]
@@ -145,10 +155,19 @@ impl CreatedBy {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct TriggerSummary {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
+    #[builder(setter(into))]
     pub title: String,
+
+    #[builder(setter(into))]
     pub template_id: Base64Uuid,
+
+    #[builder(setter(into))]
     pub created_at: Timestamp,
+
+    #[builder(setter(into))]
     pub updated_at: Timestamp,
 }
 
@@ -189,6 +208,8 @@ pub struct NotebookPatch {
 pub struct NotebookCopyDestination {
     #[builder(setter(into))]
     pub title: String,
+
+    #[builder(setter(into))]
     pub workspace_id: Base64Uuid,
 }
 
@@ -202,6 +223,7 @@ pub struct NotebookCopyDestination {
 #[serde(rename_all = "camelCase")]
 pub struct NewPinnedNotebook {
     /// The ID of the notebook that is being pinned.
+    #[builder(setter(into))]
     pub notebook_id: Base64Uuid,
 }
 
@@ -209,18 +231,26 @@ pub struct NewPinnedNotebook {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Trigger {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
     #[builder(setter(into))]
     pub title: String,
+
+    #[builder(setter(into))]
     pub template_id: Base64Uuid,
+
     #[builder(default, setter(into, strip_option))]
     pub secret_key: Option<String>,
-    #[builder(default, setter(strip_option))]
+
+    #[builder(default, setter(into, strip_option))]
     pub default_arguments: Option<Map<String, Value>>,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
+
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
+
+    #[builder(setter(into))]
+    pub updated_at: Timestamp,
 }
 
 pub type TemplateExpandPayload = Map<String, Value>;
@@ -229,8 +259,12 @@ pub type TemplateExpandPayload = Map<String, Value>;
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct TriggerInvokeResponse {
+    #[builder(setter(into))]
     pub notebook_title: String,
+
+    #[builder(setter(into))]
     pub notebook_id: Base64Uuid,
+
     pub notebook_url: Url,
 }
 
@@ -243,15 +277,26 @@ pub struct TriggerInvokeResponse {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct NotebookSummary {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
+    #[builder(setter(into))]
     pub workspace_id: Base64Uuid,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
+
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
+
+    #[builder(setter(into))]
+    pub updated_at: Timestamp,
+
+    #[builder(setter(into))]
     pub title: String,
+
     pub visibility: NotebookVisibility,
+
     pub created_by: CreatedBy,
+
+    #[builder(default)]
     pub labels: Vec<Label>,
 }
 
@@ -265,13 +310,15 @@ pub struct NotebookSummary {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct NotebookSearch {
-    #[builder(default)]
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub labels: Option<HashMap<String, Option<String>>>,
-    #[builder(default)]
+
+    #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub relative_time: Option<RelativeTime>,
-    #[builder(default)]
+
+    #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub view: Option<Name>,
 }
@@ -285,13 +332,19 @@ pub struct NotebookSearch {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct TemplateSummary {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
     pub name: Name,
+
+    #[builder(default, setter(into))]
     pub description: String,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
+
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
+
+    #[builder(setter(into))]
+    pub updated_at: Timestamp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, TypedBuilder)]
@@ -304,8 +357,10 @@ pub struct TemplateSummary {
 #[serde(rename_all = "camelCase")]
 pub struct NewTemplate {
     pub name: Name,
-    #[builder(setter(into))]
+
+    #[builder(default, setter(into))]
     pub description: String,
+
     #[builder(setter(into))]
     pub body: String,
 }
@@ -329,9 +384,10 @@ impl NewTemplate {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateTemplate {
-    #[builder(default, setter(into))]
+    #[builder(default, setter(into, strip_option))]
     pub description: Option<String>,
-    #[builder(default, setter(into))]
+
+    #[builder(default, setter(into, strip_option))]
     pub body: Option<String>,
 }
 
@@ -341,7 +397,9 @@ pub struct UpdateTemplate {
 pub struct NewTrigger {
     #[builder(setter(into))]
     pub title: String,
+
     pub template_name: Name,
+
     #[builder(default, setter(into, strip_option))]
     pub default_arguments: Option<Map<String, Value>>,
 }
@@ -360,10 +418,12 @@ pub struct NotebookCellsAppendQuery {
     /// Append the provided cells before this cell.
     /// If the cell is not found it will return a 400. This parameter cannot
     /// be used together with `after`.
+    #[builder(default, setter(into, strip_option))]
     pub before: Option<String>,
 
     /// Append the provided cells after this cell.
     /// If the cell is not found it will return a 400. This parameter cannot
     /// be used together with `before`.
+    #[builder(default, setter(into, strip_option))]
     pub after: Option<String>,
 }

--- a/fiberplane-models/src/notebooks/mod.rs
+++ b/fiberplane-models/src/notebooks/mod.rs
@@ -77,8 +77,10 @@ pub struct Notebook {
 pub struct NewNotebook {
     #[builder(setter(into))]
     pub title: String,
+
     #[builder(default)]
     pub cells: Vec<Cell>,
+
     #[builder(setter(into))]
     pub time_range: NewTimeRange,
 
@@ -150,7 +152,7 @@ pub struct TriggerSummary {
     pub updated_at: Timestamp,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Display)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize, Display)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),
@@ -159,14 +161,9 @@ pub struct TriggerSummary {
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum NotebookVisibility {
+    #[default]
     Private,
     Public,
-}
-
-impl Default for NotebookVisibility {
-    fn default() -> Self {
-        Self::Private
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, TypedBuilder)]

--- a/fiberplane-models/src/notebooks/operations.rs
+++ b/fiberplane-models/src/notebooks/operations.rs
@@ -111,7 +111,7 @@ pub struct ReplaceCellsOperation {
     /// is replaced with the text given in the first of the `new_cells`.
     ///
     /// If `None`, no cell is split.
-    #[builder(default)]
+    #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub split_offset: Option<u32>,
 
@@ -123,7 +123,7 @@ pub struct ReplaceCellsOperation {
     /// merge offset.
     ///
     /// If `None`, no cells are merged.
-    #[builder(default)]
+    #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub merge_offset: Option<u32>,
 
@@ -235,7 +235,7 @@ pub struct ReplaceTextOperation {
     pub cell_id: String,
 
     /// Field to update the text of.
-    #[builder(default, setter(into))]
+    #[builder(default, setter(into, strip_option))]
     pub field: Option<String>,
 
     /// Starting offset where we will be replacing the text.
@@ -251,7 +251,7 @@ pub struct ReplaceTextOperation {
     /// Optional formatting that we wish to apply to the new text.
     ///
     /// Offsets in the formatting are relative to the start of the new text.
-    #[builder(default)]
+    #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub new_formatting: Option<Formatting>,
 
@@ -265,7 +265,7 @@ pub struct ReplaceTextOperation {
     /// old text's boundaries.
     ///
     /// Offsets in the formatting are relative to the start of the old text.
-    #[builder(default)]
+    #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub old_formatting: Option<Formatting>,
 }

--- a/fiberplane-models/src/notebooks/operations.rs
+++ b/fiberplane-models/src/notebooks/operations.rs
@@ -236,6 +236,7 @@ pub struct ReplaceTextOperation {
 
     /// Field to update the text of.
     #[builder(default, setter(into, strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
 
     /// Starting offset where we will be replacing the text.
@@ -252,7 +253,7 @@ pub struct ReplaceTextOperation {
     ///
     /// Offsets in the formatting are relative to the start of the new text.
     #[builder(default, setter(strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub new_formatting: Option<Formatting>,
 
     /// The old text that we're replacing.
@@ -266,7 +267,7 @@ pub struct ReplaceTextOperation {
     ///
     /// Offsets in the formatting are relative to the start of the old text.
     #[builder(default, setter(strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub old_formatting: Option<Formatting>,
 }
 
@@ -464,7 +465,7 @@ pub struct CellReplaceText {
     ///
     /// Offsets in the formatting are relative to the start of the new text.
     #[builder(default, setter(strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub new_formatting: Option<Formatting>,
 
     /// The old text that we're replacing.
@@ -478,6 +479,6 @@ pub struct CellReplaceText {
     ///
     /// Offsets in the formatting are relative to the start of the old text.
     #[builder(default, setter(strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub old_formatting: Option<Formatting>,
 }

--- a/fiberplane-models/src/notebooks/operations.rs
+++ b/fiberplane-models/src/notebooks/operations.rs
@@ -294,7 +294,10 @@ pub struct UpdateNotebookTimeRangeOperation {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateNotebookTitleOperation {
+    #[builder(default, setter(into))]
     pub old_title: String,
+
+    #[builder(default, setter(into))]
     pub title: String,
 }
 
@@ -309,9 +312,11 @@ pub struct UpdateNotebookTitleOperation {
 pub struct SetSelectedDataSourceOperation {
     #[builder(setter(into))]
     pub provider_type: String,
+
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub old_selected_data_source: Option<SelectedDataSource>,
+
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub new_selected_data_source: Option<SelectedDataSource>,
@@ -430,6 +435,7 @@ pub struct ClearFrontMatterOperation {
 pub struct CellAppendText {
     #[builder(setter(into))]
     pub content: String,
+
     #[builder(default)]
     #[serde(default)]
     pub formatting: Formatting,
@@ -451,18 +457,18 @@ pub struct CellReplaceText {
     pub offset: u32,
 
     /// The new text value we're inserting.
-    #[builder(setter(into))]
+    #[builder(default, setter(into))]
     pub new_text: String,
 
     /// Optional formatting that we wish to apply to the new text.
     ///
     /// Offsets in the formatting are relative to the start of the new text.
-    #[builder(default, setter(into))]
+    #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub new_formatting: Option<Formatting>,
 
     /// The old text that we're replacing.
-    #[builder(setter(into))]
+    #[builder(default, setter(into))]
     pub old_text: String,
 
     /// Optional formatting that was applied to the old text. This should be **all** the formatting
@@ -471,7 +477,7 @@ pub struct CellReplaceText {
     /// old text's boundaries.
     ///
     /// Offsets in the formatting are relative to the start of the old text.
-    #[builder(default, setter(into))]
+    #[builder(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub old_formatting: Option<Formatting>,
 }

--- a/fiberplane-models/src/notebooks/operations.rs
+++ b/fiberplane-models/src/notebooks/operations.rs
@@ -463,7 +463,7 @@ pub struct CellReplaceText {
     /// Optional formatting that we wish to apply to the new text.
     ///
     /// Offsets in the formatting are relative to the start of the new text.
-    #[builder(default)]
+    #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub new_formatting: Option<Formatting>,
 
@@ -477,7 +477,7 @@ pub struct CellReplaceText {
     /// old text's boundaries.
     ///
     /// Offsets in the formatting are relative to the start of the old text.
-    #[builder(default)]
+    #[builder(default, setter(strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub old_formatting: Option<Formatting>,
 }

--- a/fiberplane-models/src/providers/data.rs
+++ b/fiberplane-models/src/providers/data.rs
@@ -20,8 +20,10 @@ use typed_builder::TypedBuilder;
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderEvent {
+    #[builder(setter(into))]
     pub time: Timestamp,
-    #[builder(default)]
+
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub end_time: Option<Timestamp>,
 
@@ -29,13 +31,14 @@ pub struct ProviderEvent {
     #[serde(flatten)]
     pub otel: OtelMetadata,
 
+    #[builder(setter(into))]
     pub title: String,
 
-    #[builder(default)]
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
-    #[builder(default)]
+    #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub severity: Option<OtelSeverityNumber>,
 
@@ -78,9 +81,11 @@ pub struct OtelMetadata {
 
     pub resource: BTreeMap<String, Value>,
 
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trace_id: Option<OtelTraceId>,
 
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub span_id: Option<OtelSpanId>,
 }
@@ -107,11 +112,23 @@ pub struct OtelSeverityNumber(pub u8);
 )]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
-pub struct OtelSpanId(pub [u8; 8]);
+pub struct OtelSpanId([u8; 8]);
 
 impl OtelSpanId {
+    /// Creates a new span ID from the raw data.
     pub fn new(data: [u8; 8]) -> Self {
         Self(data)
+    }
+
+    /// Returns the raw bytes of the span ID.
+    pub fn raw(&self) -> &[u8; 8] {
+        &self.0
+    }
+}
+
+impl From<[u8; 8]> for OtelSpanId {
+    fn from(value: [u8; 8]) -> Self {
+        Self::new(value)
     }
 }
 
@@ -125,11 +142,23 @@ impl OtelSpanId {
 )]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
-pub struct OtelTraceId(pub [u8; 16]);
+pub struct OtelTraceId([u8; 16]);
 
 impl OtelTraceId {
+    /// Creates a new trace ID from the raw data.
     pub fn new(data: [u8; 16]) -> Self {
         Self(data)
+    }
+
+    /// Returns the raw bytes of the trace ID.
+    pub fn raw(&self) -> &[u8; 16] {
+        &self.0
+    }
+}
+
+impl From<[u8; 16]> for OtelTraceId {
+    fn from(value: [u8; 16]) -> Self {
+        Self::new(value)
     }
 }
 
@@ -161,9 +190,15 @@ pub struct Timeline {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Timeseries {
+    #[builder(setter(into))]
     pub name: String,
+
+    #[builder(default, setter(into))]
     pub labels: BTreeMap<String, String>,
+
+    #[builder(default)]
     pub metrics: Vec<Metric>,
+
     #[serde(flatten)]
     pub otel: OtelMetadata,
 

--- a/fiberplane-models/src/providers/error.rs
+++ b/fiberplane-models/src/providers/error.rs
@@ -116,7 +116,10 @@ impl From<time::error::Parse> for Error {
 #[serde(rename_all = "camelCase")]
 pub struct ValidationError {
     /// Refers to a field from the query schema.
+    #[builder(setter(into))]
     pub field_name: String,
+
     /// Description of why the validation failed.
+    #[builder(setter(into))]
     pub message: String,
 }

--- a/fiberplane-models/src/providers/schema/config_schema.rs
+++ b/fiberplane-models/src/providers/schema/config_schema.rs
@@ -1,8 +1,7 @@
+use super::fields::*;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-
-use super::fields::*;
 
 /// Defines the fields that should be included in a provider's config.
 ///

--- a/fiberplane-models/src/providers/schema/fields/array_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/array_field.rs
@@ -54,7 +54,13 @@ pub struct ArrayField {
     ///   .with_label("example".to_string())
     ///   .with_element_schema(vec![
     ///     TextField::new().with_name("key").into(),
-    ///     SelectField::new().with_name("operator").with_options(&["<", ">", "<=", ">=", "=="]).into(),
+    ///     SelectField::new().with_name("operator").with_options([
+    ///       "<".into(),
+    ///       ">".into(),
+    ///       "<=".into(),
+    ///       ">=".into(),
+    ///       "==".into()
+    ///     ]).into(),
     ///     IntegerField::new().with_name("value").into(),
     ///   ]);
     /// ```

--- a/fiberplane-models/src/providers/schema/fields/checkbox_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/checkbox_field.rs
@@ -64,23 +64,23 @@ impl CheckboxField {
         }
     }
 
-    pub fn with_label(self, label: &str) -> Self {
+    pub fn with_label(self, label: impl Into<String>) -> Self {
         Self {
-            label: label.to_owned(),
+            label: label.into(),
             ..self
         }
     }
 
-    pub fn with_name(self, name: &str) -> Self {
+    pub fn with_name(self, name: impl Into<String>) -> Self {
         Self {
-            name: name.to_owned(),
+            name: name.into(),
             ..self
         }
     }
 
-    pub fn with_value(self, value: &str) -> Self {
+    pub fn with_value(self, value: impl Into<String>) -> Self {
         Self {
-            value: value.to_owned(),
+            value: value.into(),
             ..self
         }
     }

--- a/fiberplane-models/src/providers/schema/fields/checkbox_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/checkbox_field.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a field that produces a boolean value.
 ///
@@ -9,7 +8,7 @@ use typed_builder::TypedBuilder;
 /// In the case of "application/x-www-form-urlencoded", it will be represented
 /// by the value defined in the `value` field, which will be either present or
 /// not, similar to the encoding of HTML forms.
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/date_time_range_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/date_time_range_field.rs
@@ -46,23 +46,23 @@ impl DateTimeRangeField {
         }
     }
 
-    pub fn with_label(self, label: &str) -> Self {
+    pub fn with_label(self, label: impl Into<String>) -> Self {
         Self {
-            label: label.to_owned(),
+            label: label.into(),
             ..self
         }
     }
 
-    pub fn with_name(self, name: &str) -> Self {
+    pub fn with_name(self, name: impl Into<String>) -> Self {
         Self {
-            name: name.to_owned(),
+            name: name.into(),
             ..self
         }
     }
 
-    pub fn with_placeholder(self, placeholder: &str) -> Self {
+    pub fn with_placeholder(self, placeholder: impl Into<String>) -> Self {
         Self {
-            placeholder: placeholder.to_owned(),
+            placeholder: placeholder.into(),
             ..self
         }
     }

--- a/fiberplane-models/src/providers/schema/fields/date_time_range_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/date_time_range_field.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a field that produces two `DateTime` values, a "from" and a "to"
 /// value.
@@ -10,7 +9,7 @@ use typed_builder::TypedBuilder;
 /// `from` and `to` fields. In the case of "application/x-www-form-urlencoded",
 /// it will be represented as a single string and the "from" and "to" parts will
 /// be separated by a space.
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/file_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/file_field.rs
@@ -50,16 +50,16 @@ impl FileField {
         }
     }
 
-    pub fn with_label(self, label: &str) -> Self {
+    pub fn with_label(self, label: impl Into<String>) -> Self {
         Self {
-            label: label.to_owned(),
+            label: label.into(),
             ..self
         }
     }
 
-    pub fn with_name(self, name: &str) -> Self {
+    pub fn with_name(self, name: impl Into<String>) -> Self {
         Self {
-            name: name.to_owned(),
+            name: name.into(),
             ..self
         }
     }

--- a/fiberplane-models/src/providers/schema/fields/file_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/file_field.rs
@@ -1,12 +1,11 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a field that allows files to be uploaded as part of the query data.
 ///
 /// Query data that includes files will be encoded using "multipart/form-data".
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/integer_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/integer_field.rs
@@ -63,9 +63,9 @@ impl IntegerField {
         }
     }
 
-    pub fn with_label(self, label: &str) -> Self {
+    pub fn with_label(self, label: impl Into<String>) -> Self {
         Self {
-            label: label.to_owned(),
+            label: label.into(),
             ..self
         }
     }
@@ -84,9 +84,9 @@ impl IntegerField {
         }
     }
 
-    pub fn with_name(self, name: &str) -> Self {
+    pub fn with_name(self, name: impl Into<String>) -> Self {
         Self {
-            name: name.to_owned(),
+            name: name.into(),
             ..self
         }
     }

--- a/fiberplane-models/src/providers/schema/fields/integer_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/integer_field.rs
@@ -1,10 +1,9 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a field that allows integer numbers to be entered.
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/label_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/label_field.rs
@@ -57,23 +57,23 @@ impl LabelField {
         }
     }
 
-    pub fn with_label(self, label: &str) -> Self {
+    pub fn with_label(self, label: impl Into<String>) -> Self {
         Self {
-            label: label.to_owned(),
+            label: label.into(),
             ..self
         }
     }
 
-    pub fn with_name(self, name: &str) -> Self {
+    pub fn with_name(self, name: impl Into<String>) -> Self {
         Self {
-            name: name.to_owned(),
+            name: name.into(),
             ..self
         }
     }
 
-    pub fn with_placeholder(self, placeholder: &str) -> Self {
+    pub fn with_placeholder(self, placeholder: impl Into<String>) -> Self {
         Self {
-            placeholder: placeholder.to_owned(),
+            placeholder: placeholder.into(),
             ..self
         }
     }

--- a/fiberplane-models/src/providers/schema/fields/label_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/label_field.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a field that allows labels to be selected.
 ///
@@ -9,7 +8,7 @@ use typed_builder::TypedBuilder;
 /// array of strings, depending on the value of the `multiple` field. In the
 /// case of "application/x-www-form-urlencoded", the value is always a single
 /// string and multiple labels will be space-separated.
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/select_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/select_field.rs
@@ -70,37 +70,37 @@ impl SelectField {
         }
     }
 
-    pub fn with_label(self, label: &str) -> Self {
+    pub fn with_label(self, label: impl Into<String>) -> Self {
         Self {
-            label: label.to_owned(),
+            label: label.into(),
             ..self
         }
     }
 
-    pub fn with_name(self, name: &str) -> Self {
+    pub fn with_name(self, name: impl Into<String>) -> Self {
         Self {
-            name: name.to_owned(),
+            name: name.into(),
             ..self
         }
     }
 
-    pub fn with_options(self, options: &[&str]) -> Self {
+    pub fn with_options(self, options: impl Into<Vec<String>>) -> Self {
         Self {
-            options: options.iter().map(|&s| s.to_owned()).collect(),
+            options: options.into(),
             ..self
         }
     }
 
-    pub fn with_placeholder(self, placeholder: &str) -> Self {
+    pub fn with_placeholder(self, placeholder: impl Into<String>) -> Self {
         Self {
-            placeholder: placeholder.to_owned(),
+            placeholder: placeholder.into(),
             ..self
         }
     }
 
-    pub fn with_prerequisites(self, prerequisites: &[&str]) -> Self {
+    pub fn with_prerequisites(self, prerequisites: impl Into<Vec<String>>) -> Self {
         Self {
-            prerequisites: prerequisites.iter().map(|&s| s.to_owned()).collect(),
+            prerequisites: prerequisites.into(),
             ..self
         }
     }

--- a/fiberplane-models/src/providers/schema/fields/select_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/select_field.rs
@@ -1,13 +1,12 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a field that allows selection from a predefined list of options.
 ///
 /// Values to be selected from can be either hard-coded in the schema, or
 /// (only for query forms) fetched on-demand the same way as auto-suggestions.
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/fields/text_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/text_field.rs
@@ -73,30 +73,30 @@ impl TextField {
         }
     }
 
-    pub fn with_label(self, label: &str) -> Self {
+    pub fn with_label(self, label: impl Into<String>) -> Self {
         Self {
-            label: label.to_owned(),
+            label: label.into(),
             ..self
         }
     }
 
-    pub fn with_name(self, name: &str) -> Self {
+    pub fn with_name(self, name: impl Into<String>) -> Self {
         Self {
-            name: name.to_owned(),
+            name: name.into(),
             ..self
         }
     }
 
-    pub fn with_placeholder(self, placeholder: &str) -> Self {
+    pub fn with_placeholder(self, placeholder: impl Into<String>) -> Self {
         Self {
-            placeholder: placeholder.to_owned(),
+            placeholder: placeholder.into(),
             ..self
         }
     }
 
-    pub fn with_prerequisites(self, prerequisites: &[&str]) -> Self {
+    pub fn with_prerequisites(self, prerequisites: impl Into<Vec<String>>) -> Self {
         Self {
-            prerequisites: prerequisites.iter().map(|&s| s.to_owned()).collect(),
+            prerequisites: prerequisites.into(),
             ..self
         }
     }

--- a/fiberplane-models/src/providers/schema/fields/text_field.rs
+++ b/fiberplane-models/src/providers/schema/fields/text_field.rs
@@ -1,12 +1,11 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
 
 /// Defines a free-form text entry field.
 ///
 /// This is commonly used for filter text and query entry.
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/schema/query_schema.rs
+++ b/fiberplane-models/src/providers/schema/query_schema.rs
@@ -1,8 +1,7 @@
+use super::fields::*;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-
-use super::fields::*;
 
 /// Defines the fields that should be included in the query data.
 ///

--- a/fiberplane-models/src/providers/schema/supported_query_type.rs
+++ b/fiberplane-models/src/providers/schema/supported_query_type.rs
@@ -1,12 +1,10 @@
+use super::QuerySchema;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
-
-use super::QuerySchema;
 
 /// Defines a query type supported by a provider.
-#[derive(Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/providers/status.rs
+++ b/fiberplane-models/src/providers/status.rs
@@ -24,12 +24,14 @@ pub struct ProviderStatus {
     ///
     /// Arbitrary strings may be used, such as commit hashes, but release
     /// versions of providers are expected to report semver versions.
+    #[builder(setter(into))]
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub version: String,
 
     /// Human-readable timestamp at which the provider was built.
     ///
     /// Only used for diagnostics.
+    #[builder(default, setter(into))]
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub built_at: String,
 }

--- a/fiberplane-models/src/proxies.rs
+++ b/fiberplane-models/src/proxies.rs
@@ -18,18 +18,27 @@ use typed_builder::TypedBuilder;
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Proxy {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
     pub name: Name,
+
     pub status: ProxyStatus,
+
     #[builder(default)]
     pub data_sources: Vec<DataSource>,
+
     #[builder(default, setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token: Option<ProxyToken>,
-    #[builder(default, setter(into))]
+
+    #[builder(default, setter(into, strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
     #[builder(setter(into))]
     pub created_at: OffsetDateTime,
+
     #[builder(setter(into))]
     pub updated_at: OffsetDateTime,
 }
@@ -43,8 +52,11 @@ pub struct Proxy {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ProxySummary {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
     pub name: Name,
+
     pub status: ProxyStatus,
 }
 
@@ -81,7 +93,8 @@ pub enum ProxyStatus {
 #[serde(rename_all = "camelCase")]
 pub struct NewProxy {
     pub name: Name,
-    #[builder(default, setter(into))]
+
+    #[builder(default, setter(into, strip_option))]
     pub description: Option<String>,
 }
 
@@ -114,8 +127,10 @@ pub enum InvalidProxyToken {
 pub struct ProxyToken {
     #[builder(setter(into))]
     pub workspace_id: Base64Uuid,
+
     pub proxy_name: Name,
-    #[builder(setter(into))]
+
+    #[builder(default, setter(into))]
     pub token: String,
 }
 
@@ -177,6 +192,8 @@ impl TryFrom<&str> for ProxyToken {
 #[serde(rename_all = "camelCase")]
 pub struct CreateCellsApiRequest {
     pub response: Blob,
+
+    #[builder(setter(into))]
     pub query_type: String,
 }
 
@@ -190,7 +207,11 @@ pub struct CreateCellsApiRequest {
 #[serde(rename_all = "camelCase")]
 pub struct ExtractDataApiRequest {
     pub response: Blob,
+
+    #[builder(setter(into))]
     pub mime_type: String,
+
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub query: Option<String>,
 }
@@ -205,9 +226,13 @@ pub struct ExtractDataApiRequest {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ServerMessage {
+    #[builder(setter(into))]
     pub op_id: Base64Uuid,
+
     pub data_source_name: Name,
+
     pub protocol_version: u8,
+
     #[serde(flatten)]
     pub payload: ServerMessagePayload,
 }
@@ -254,6 +279,7 @@ impl ServerMessage {
             op_id,
         )
     }
+
     pub fn new_create_cells_request(
         data: Blob,
         query_type: String,
@@ -271,6 +297,7 @@ impl ServerMessage {
             op_id,
         )
     }
+
     pub fn new_extract_data_request(
         data: Blob,
         mime_type: String,
@@ -290,6 +317,7 @@ impl ServerMessage {
             op_id,
         )
     }
+
     pub fn new_get_config_schema_request(
         data_source_name: Name,
         protocol_version: u8,
@@ -302,6 +330,7 @@ impl ServerMessage {
             op_id,
         )
     }
+
     pub fn new_get_supported_query_types_request(
         config: ProviderConfig,
         data_source_name: Name,
@@ -371,6 +400,8 @@ impl Debug for InvokeRequest {
 #[serde(rename_all = "camelCase")]
 pub struct CreateCellsRequest {
     pub response: Blob,
+
+    #[builder(setter(into))]
     pub query_type: String,
 }
 
@@ -393,7 +424,11 @@ impl Debug for CreateCellsRequest {
 #[serde(rename_all = "camelCase")]
 pub struct ExtractDataRequest {
     pub response: Blob,
+
+    #[builder(setter(into))]
     pub mime_type: String,
+
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub query: Option<String>,
 }
@@ -446,7 +481,9 @@ pub struct GetSupportedQueryTypesRequest {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ProxyMessage {
+    #[builder(default, setter(into, strip_option))]
     pub op_id: Option<Base64Uuid>,
+
     #[serde(flatten)]
     pub payload: ProxyMessagePayload,
 }
@@ -655,13 +692,17 @@ pub struct SetDataSourcesMessage {
 #[serde(tag = "type", rename_all = "camelCase")]
 pub struct UpsertProxyDataSource {
     pub name: Name,
-    #[builder(default, setter(into))]
+
+    #[builder(default, setter(into, strip_option))]
     pub description: Option<String>,
+
     #[builder(setter(into))]
     pub provider_type: String,
+
     #[builder(default)]
     #[serde(default)]
     pub protocol_version: u8,
+
     #[serde(flatten)]
     pub status: DataSourceStatus,
 }

--- a/fiberplane-models/src/proxies.rs
+++ b/fiberplane-models/src/proxies.rs
@@ -4,6 +4,7 @@ use super::providers::Error;
 use crate::blobs::Blob;
 use crate::notebooks::Cell;
 use crate::providers::{ConfigSchema, ProviderConfig, SupportedQueryType};
+use crate::timestamps::Timestamp;
 use base64uuid::{Base64Uuid, InvalidId};
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
@@ -11,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Formatter};
 use std::{convert::TryFrom, str::FromStr};
 use strum_macros::Display;
-use time::OffsetDateTime;
 use typed_builder::TypedBuilder;
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, TypedBuilder)]
@@ -37,10 +37,10 @@ pub struct Proxy {
     pub description: Option<String>,
 
     #[builder(setter(into))]
-    pub created_at: OffsetDateTime,
+    pub created_at: Timestamp,
 
     #[builder(setter(into))]
-    pub updated_at: OffsetDateTime,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, TypedBuilder)]

--- a/fiberplane-models/src/realtime.rs
+++ b/fiberplane-models/src/realtime.rs
@@ -2,13 +2,13 @@ use crate::comments::{Thread, ThreadItem, UserSummary};
 use crate::events::Event;
 use crate::labels::LabelValidationError;
 use crate::notebooks::operations::Operation;
+use crate::timestamps::Timestamp;
 use base64uuid::Base64Uuid;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::fmt::Debug;
-use time::OffsetDateTime;
 use typed_builder::TypedBuilder;
 
 /// Real-time message sent by the client over a WebSocket connection.
@@ -144,11 +144,14 @@ pub enum ServerRealtimeMessage {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct AuthenticateMessage {
-    /// Bearer token
+    /// Bearer token.
     #[builder(setter(into))]
     pub token: String,
 
-    /// Operation ID
+    /// Operation ID.
+    ///
+    /// Only messages with an operation ID will receive an `Ack` from the
+    /// server.
     #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
@@ -172,18 +175,21 @@ impl Debug for AuthenticateMessage {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct SubscribeMessage {
-    /// ID of the notebook
+    /// ID of the notebook.
     #[builder(setter(into))]
     pub notebook_id: String,
 
     /// The current revision that the client knows about. If this is not the
     /// current revision according to the server, than the server will sent
     /// all operations starting from this revision.
-    #[builder(default, setter(into))]
+    #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub revision: Option<u32>,
 
-    /// Operation ID
+    /// Operation ID.
+    ///
+    /// Only messages with an operation ID will receive an `Ack` from the
+    /// server.
     #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
@@ -198,11 +204,14 @@ pub struct SubscribeMessage {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct UnsubscribeMessage {
-    /// ID of the notebook
+    /// ID of the notebook.
     #[builder(setter(into))]
     pub notebook_id: String,
 
-    /// Operation ID
+    /// Operation ID.
+    ///
+    /// Only messages with an operation ID will receive an `Ack` from the
+    /// server.
     #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
@@ -217,19 +226,27 @@ pub struct UnsubscribeMessage {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ApplyOperationMessage {
-    /// ID of the notebook
+    /// ID of the notebook.
     #[builder(setter(into))]
     pub notebook_id: String,
 
-    /// Operation
+    /// The operation to apply.
     pub operation: Operation,
 
-    /// Revision, for a client sending this message it means the desired new
-    /// revision. When it is sent from a server it is the actual revision.
+    /// The revision assigned to the operation.
+    ///
+    /// If a client sends this message, it *requests* this revision to be
+    /// assigned and the operation may be rejected if the revision is already
+    /// assigned.
+    ///
+    /// When a client receives this message, it is the actual revision.
     pub revision: u32,
 
-    /// Operation ID
-    #[builder(default, setter(into))]
+    /// Operation ID.
+    ///
+    /// Only messages with an operation ID will receive an `Ack` from the
+    /// server.
+    #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
@@ -259,19 +276,26 @@ impl ApplyOperationMessage {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ApplyOperationBatchMessage {
-    /// ID of the notebook
+    /// ID of the notebook.
     #[builder(setter(into))]
     pub notebook_id: String,
 
-    /// Operation
-    #[builder(default)]
+    /// The operations to apply.
     pub operations: Vec<Operation>,
 
-    /// Revision, this will be the revision of the first operation. The other
-    /// operations will keep bumping the revision.
+    /// The revision assigned to the operation.
+    ///
+    /// If a client sends this message, it *requests* this revision to be
+    /// assigned and the operations may be rejected if the revision is already
+    /// assigned.
+    ///
+    /// When a client receives this message, it is the actual revision.
     pub revision: u32,
 
-    /// Operation ID
+    /// Operation ID.
+    ///
+    /// Only messages with an operation ID will receive an `Ack` from the
+    /// server.
     #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
@@ -293,7 +317,11 @@ impl ApplyOperationBatchMessage {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
+/// Acknowledgement that the server has received and successfully processed an
+/// operation sent by the client.
+///
+/// Acknowledgement are only sent for client message that include some `op_id`.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),
@@ -302,7 +330,8 @@ impl ApplyOperationBatchMessage {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct AckMessage {
-    /// Operation ID.
+    /// ID of the operation being acknowledged. This matches the `op_id` sent by
+    /// the client.
     pub op_id: String,
 }
 
@@ -325,8 +354,11 @@ pub struct ErrMessage {
     #[builder(setter(into))]
     pub error_message: String,
 
-    /// Operation ID. Empty if the user has not provided a op_id.
-    #[builder(default, setter(into))]
+    /// Operation ID.
+    ///
+    /// Only messages with an operation ID will receive an `Ack` from the
+    /// server.
+    #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
@@ -341,6 +373,10 @@ pub struct ErrMessage {
 #[serde(rename_all = "camelCase")]
 pub struct DebugRequestMessage {
     /// Operation ID.
+    ///
+    /// Only messages with an operation ID will receive an `Ack` from the
+    /// server.
+    #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
@@ -355,14 +391,18 @@ pub struct DebugRequestMessage {
 #[serde(rename_all = "camelCase")]
 pub struct DebugResponseMessage {
     /// Session ID.
+    #[builder(setter(into))]
     pub sid: String,
 
     /// Notebooks that the user is subscribed to.
     #[builder(default)]
     pub subscribed_notebooks: Vec<String>,
 
-    /// Operation ID. Empty if the user has not provided a op_id.
-    #[builder(default, setter(into))]
+    /// Operation ID.
+    ///
+    /// Only messages with an operation ID will receive an `Ack` from the
+    /// server.
+    #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
@@ -377,6 +417,7 @@ pub struct DebugResponseMessage {
 #[serde(rename_all = "camelCase")]
 pub struct EventAddedMessage {
     /// ID of workspace in which the event was added.
+    #[builder(setter(into))]
     pub workspace_id: Base64Uuid,
 
     /// The event that was added.
@@ -393,6 +434,7 @@ pub struct EventAddedMessage {
 #[serde(rename_all = "camelCase")]
 pub struct EventUpdatedMessage {
     /// ID of workspace in which the event was updated.
+    #[builder(setter(into))]
     pub workspace_id: Base64Uuid,
 
     /// The event that was updated.
@@ -409,6 +451,7 @@ pub struct EventUpdatedMessage {
 #[serde(rename_all = "camelCase")]
 pub struct EventDeletedMessage {
     /// ID of workspace in which the event was deleted.
+    #[builder(setter(into))]
     pub workspace_id: Base64Uuid,
 
     /// ID of the event that was deleted.
@@ -425,9 +468,11 @@ pub struct EventDeletedMessage {
 #[serde(rename_all = "camelCase")]
 pub struct MentionMessage {
     /// ID of the notebook in which the user was mentioned.
+    #[builder(setter(into))]
     pub notebook_id: String,
 
     /// ID of the cell in which the user was mentioned.
+    #[builder(setter(into))]
     pub cell_id: String,
 
     /// Who mentioned the user?
@@ -443,11 +488,12 @@ pub struct MentionMessage {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct MentionedBy {
+    #[builder(setter(into))]
     pub name: String,
 }
 
 /// Message sent when an apply operation was rejected by the server.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),
@@ -456,11 +502,14 @@ pub struct MentionedBy {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct RejectedMessage {
-    /// The reason why the apply operation was rejected.
+    /// The reason why the operation was rejected.
     pub reason: Box<RejectReason>,
 
-    /// Operation ID. Empty if the user has not provided a op_id.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Operation ID.
+    ///
+    /// Only messages with an operation ID will receive an `Ack` from the
+    /// server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
 
@@ -580,13 +629,11 @@ pub struct SubscriberAddedMessage {
 
     /// The moment the session was created.
     #[builder(setter(into))]
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
+    pub created_at: Timestamp,
 
     /// The last time the user was active in this session.
     #[builder(setter(into))]
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
+    pub updated_at: Timestamp,
 
     /// User details associated with the session.
     pub user: User,
@@ -607,9 +654,11 @@ pub struct SubscriberAddedMessage {
 #[serde(rename_all = "camelCase")]
 pub struct SubscriberRemovedMessage {
     /// The ID of the notebook that the user unsubscribed from.
+    #[builder(setter(into))]
     pub notebook_id: String,
 
     /// ID of the session that was removed.
+    #[builder(setter(into))]
     pub session_id: String,
 }
 
@@ -650,7 +699,10 @@ pub struct FocusInfoMessage {
     #[serde(default)]
     pub focus: NotebookFocus,
 
-    /// Operation ID. Empty if the user has not provided a op_id.
+    /// Operation ID.
+    ///
+    /// Only messages with an operation ID will receive an `Ack` from the
+    /// server.
     #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
@@ -667,12 +719,16 @@ pub struct FocusInfoMessage {
 pub struct UserTypingCommentClientMessage {
     #[builder(setter(into))]
     pub notebook_id: Base64Uuid,
+
     #[builder(setter(into))]
     pub thread_id: Base64Uuid,
 
-    /// Operation ID. Empty if the user has not provided a op_id.
+    /// Operation ID.
+    ///
+    /// Only messages with an operation ID will receive an `Ack` from the
+    /// server.
     #[builder(default, setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
 
@@ -685,12 +741,16 @@ pub struct UserTypingCommentClientMessage {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct SubscribeWorkspaceMessage {
-    /// ID of the workspace
+    /// ID of the workspace.
+    #[builder(setter(into))]
     pub workspace_id: Base64Uuid,
 
-    /// Operation ID
+    /// Operation ID.
+    ///
+    /// Only messages with an operation ID will receive an `Ack` from the
+    /// server.
     #[builder(default, setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
 
@@ -703,11 +763,16 @@ pub struct SubscribeWorkspaceMessage {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct UnsubscribeWorkspaceMessage {
-    /// ID of the workspace
+    /// ID of the workspace.
+    #[builder(setter(into))]
     pub workspace_id: Base64Uuid,
 
-    /// Operation ID
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Operation ID.
+    ///
+    /// Only messages with an operation ID will receive an `Ack` from the
+    /// server.
+    #[builder(default, setter(into, strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
 
@@ -721,9 +786,11 @@ pub struct UnsubscribeWorkspaceMessage {
 #[serde(rename_all = "camelCase")]
 pub struct SubscriberChangedFocusMessage {
     /// ID of the session.
+    #[builder(setter(into))]
     pub session_id: String,
 
     /// ID of the notebook.
+    #[builder(setter(into))]
     pub notebook_id: String,
 
     /// User's focus within the notebook.
@@ -759,17 +826,17 @@ pub struct FocusPosition {
     /// Note that fields do not necessarily have to be text fields. For example,
     /// we could also use this to indicate the user has focused a button for
     /// graph navigation.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
 
     /// Offset within the text field.
     /// May be `None` if the focus is not inside a text field.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub offset: Option<u32>,
 }
 
 /// Specifies the user's focus and optional selection within the notebook.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),
@@ -779,6 +846,7 @@ pub struct FocusPosition {
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum NotebookFocus {
     /// The user has no focus within the notebook.
+    #[default]
     None,
     /// The user focus is within the notebook and the focus is on a single
     /// position. I.e. there is no selection.
@@ -954,12 +1022,6 @@ impl NotebookFocus {
     }
 }
 
-impl Default for NotebookFocus {
-    fn default() -> Self {
-        Self::None
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
 #[cfg_attr(
     feature = "fp-bindgen",
@@ -969,7 +1031,9 @@ impl Default for NotebookFocus {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadAddedMessage {
+    #[builder(setter(into))]
     pub notebook_id: String,
+
     pub thread: Thread,
 }
 
@@ -982,8 +1046,12 @@ pub struct ThreadAddedMessage {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadItemAddedMessage {
+    #[builder(setter(into))]
     pub notebook_id: String,
+
+    #[builder(setter(into))]
     pub thread_id: String,
+
     pub thread_item: ThreadItem,
 }
 
@@ -996,8 +1064,12 @@ pub struct ThreadItemAddedMessage {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadItemUpdatedMessage {
+    #[builder(setter(into))]
     pub notebook_id: String,
+
+    #[builder(setter(into))]
     pub thread_id: String,
+
     pub thread_item: ThreadItem,
 }
 
@@ -1010,7 +1082,10 @@ pub struct ThreadItemUpdatedMessage {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct ThreadDeletedMessage {
+    #[builder(setter(into))]
     pub notebook_id: String,
+
+    #[builder(setter(into))]
     pub thread_id: String,
 }
 
@@ -1023,11 +1098,16 @@ pub struct ThreadDeletedMessage {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct UserTypingCommentServerMessage {
+    #[builder(setter(into))]
     pub notebook_id: String,
+
+    #[builder(setter(into))]
     pub thread_id: String,
+
     pub user: UserSummary,
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
+
+    #[builder(setter(into))]
+    pub updated_at: Timestamp,
 }
 
 #[cfg(test)]

--- a/fiberplane-models/src/realtime.rs
+++ b/fiberplane-models/src/realtime.rs
@@ -153,7 +153,7 @@ pub struct AuthenticateMessage {
     /// Only messages with an operation ID will receive an `Ack` from the
     /// server.
     #[builder(default, setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
 
@@ -191,7 +191,7 @@ pub struct SubscribeMessage {
     /// Only messages with an operation ID will receive an `Ack` from the
     /// server.
     #[builder(default, setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
 
@@ -213,7 +213,7 @@ pub struct UnsubscribeMessage {
     /// Only messages with an operation ID will receive an `Ack` from the
     /// server.
     #[builder(default, setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
 
@@ -247,7 +247,7 @@ pub struct ApplyOperationMessage {
     /// Only messages with an operation ID will receive an `Ack` from the
     /// server.
     #[builder(default, setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
 
@@ -281,7 +281,7 @@ pub struct ApplyOperationBatchMessage {
     /// Only messages with an operation ID will receive an `Ack` from the
     /// server.
     #[builder(default, setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
 
@@ -325,7 +325,7 @@ pub struct ErrMessage {
     ///
     /// This will match the operation ID of the client message that triggered
     /// the error.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
 
@@ -358,7 +358,7 @@ pub struct DebugRequestMessage {
     /// Only messages with an operation ID will receive an `Ack` from the
     /// server.
     #[builder(default, setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
 
@@ -384,7 +384,7 @@ pub struct DebugResponseMessage {
     /// Only messages with an operation ID will receive an `Ack` from the
     /// server.
     #[builder(default, setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
 
@@ -685,7 +685,7 @@ pub struct FocusInfoMessage {
     /// Only messages with an operation ID will receive an `Ack` from the
     /// server.
     #[builder(default, setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
 }
 

--- a/fiberplane-models/src/realtime.rs
+++ b/fiberplane-models/src/realtime.rs
@@ -309,7 +309,7 @@ impl AckMessage {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),
@@ -319,16 +319,29 @@ impl AckMessage {
 #[serde(rename_all = "camelCase")]
 pub struct ErrMessage {
     /// Error message.
-    #[builder(setter(into))]
     pub error_message: String,
 
     /// Operation ID.
     ///
-    /// Only messages with an operation ID will receive an `Ack` from the
-    /// server.
-    #[builder(default, setter(into, strip_option))]
+    /// This will match the operation ID of the client message that triggered
+    /// the error.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
+}
+
+impl ErrMessage {
+    /// Creates a new error with the given message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            error_message: message.into(),
+            op_id: None,
+        }
+    }
+
+    /// Assigns the optional operation ID to the message.
+    pub fn with_optional_op_id(self, op_id: Option<String>) -> Self {
+        Self { op_id, ..self }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]

--- a/fiberplane-models/src/realtime.rs
+++ b/fiberplane-models/src/realtime.rs
@@ -251,22 +251,6 @@ pub struct ApplyOperationMessage {
     pub op_id: Option<String>,
 }
 
-impl ApplyOperationMessage {
-    pub fn new(
-        notebook_id: String,
-        operation: Operation,
-        revision: u32,
-        op_id: Option<String>,
-    ) -> Self {
-        Self {
-            notebook_id,
-            operation,
-            revision,
-            op_id,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, TypedBuilder)]
 #[cfg_attr(
     feature = "fp-bindgen",
@@ -299,22 +283,6 @@ pub struct ApplyOperationBatchMessage {
     #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub op_id: Option<String>,
-}
-
-impl ApplyOperationBatchMessage {
-    pub fn new(
-        notebook_id: String,
-        operations: Vec<Operation>,
-        revision: u32,
-        op_id: Option<String>,
-    ) -> Self {
-        Self {
-            notebook_id,
-            operations,
-            revision,
-            op_id,
-        }
-    }
 }
 
 /// Acknowledgement that the server has received and successfully processed an

--- a/fiberplane-models/src/snippets.rs
+++ b/fiberplane-models/src/snippets.rs
@@ -76,7 +76,7 @@ pub struct NewSnippet {
     pub body: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, TypedBuilder)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, TypedBuilder)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/snippets.rs
+++ b/fiberplane-models/src/snippets.rs
@@ -15,11 +15,21 @@ use typed_builder::TypedBuilder;
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Snippet {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
     pub name: Name,
+
+    #[builder(setter(into))]
     pub description: String,
+
+    #[builder(setter(into))]
     pub body: String,
+
+    #[builder(setter(into))]
     pub created_at: Timestamp,
+
+    #[builder(setter(into))]
     pub updated_at: Timestamp,
 }
 
@@ -32,10 +42,18 @@ pub struct Snippet {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct SnippetSummary {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
     pub name: Name,
+
+    #[builder(default, setter(into))]
     pub description: String,
+
+    #[builder(setter(into))]
     pub created_at: Timestamp,
+
+    #[builder(setter(into))]
     pub updated_at: Timestamp,
 }
 
@@ -49,9 +67,11 @@ pub struct SnippetSummary {
 #[serde(rename_all = "camelCase")]
 pub struct NewSnippet {
     pub name: Name,
+
     #[builder(default, setter(into))]
     #[serde(default)]
     pub description: String,
+
     #[builder(setter(into))]
     pub body: String,
 }
@@ -65,10 +85,11 @@ pub struct NewSnippet {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateSnippet {
-    #[builder(default, setter(into))]
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[builder(default, setter(into))]
+
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
 }

--- a/fiberplane-models/src/templates.rs
+++ b/fiberplane-models/src/templates.rs
@@ -1,13 +1,12 @@
-use crate::names::Name;
+use crate::{names::Name, timestamps::Timestamp};
 use base64uuid::Base64Uuid;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use time::OffsetDateTime;
 use typed_builder::TypedBuilder;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),
@@ -27,13 +26,8 @@ pub enum TemplateParameterType {
     Array,
     /// We can only extract the parameter type from function parameters
     /// that have default values
+    #[default]
     Unknown,
-}
-
-impl Default for TemplateParameterType {
-    fn default() -> Self {
-        Self::Unknown
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TypedBuilder)]
@@ -47,9 +41,11 @@ impl Default for TemplateParameterType {
 pub struct TemplateParameter {
     #[builder(setter(into))]
     pub name: String,
+
     #[builder(default)]
     #[serde(rename = "type")]
     pub ty: TemplateParameterType,
+
     #[builder(default, setter(into, strip_option))]
     pub default_value: Option<Value>,
 }
@@ -63,13 +59,22 @@ pub struct TemplateParameter {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Template {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
     pub name: Name,
+
+    #[builder(default, setter(into))]
     pub description: String,
+
+    #[builder(setter(into))]
     pub body: String,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
+
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
+
+    #[builder(setter(into))]
+    pub updated_at: Timestamp,
+
     pub parameters: Vec<TemplateParameter>,
 }

--- a/fiberplane-models/src/timestamps.rs
+++ b/fiberplane-models/src/timestamps.rs
@@ -1,15 +1,13 @@
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt,
-    ops::{Deref, Sub},
-    str::FromStr,
-    time::SystemTime,
-};
-use time::{
-    ext::NumericalDuration, format_description::well_known::Rfc3339, Duration, OffsetDateTime,
-};
+use std::fmt;
+use std::ops::{Add, Deref, Sub};
+use std::str::FromStr;
+use std::time::SystemTime;
+use time::ext::NumericalDuration;
+use time::format_description::well_known::Rfc3339;
+use time::{Duration, OffsetDateTime};
 
 /// A range in time from a given timestamp (inclusive) up to another timestamp
 /// (exclusive).
@@ -40,16 +38,16 @@ impl From<NewTimeRange> for TimeRange {
         match new_time_range {
             NewTimeRange::Absolute(time_range) => time_range,
             NewTimeRange::Relative(RelativeTimeRange { minutes }) => {
-                let now = OffsetDateTime::now_utc();
+                let now = Timestamp::now_utc();
                 if minutes < 0 {
                     TimeRange {
-                        from: (now + (minutes as i64).minutes()).into(),
-                        to: now.into(),
+                        from: now + (minutes as i64).minutes(),
+                        to: now,
                     }
                 } else {
                     TimeRange {
-                        from: now.into(),
-                        to: (now + (minutes as i64).minutes()).into(),
+                        from: now,
+                        to: now + (minutes as i64).minutes(),
                     }
                 }
             }
@@ -66,7 +64,13 @@ impl From<NewTimeRange> for TimeRange {
 pub struct Timestamp(#[serde(with = "time::serde::rfc3339")] OffsetDateTime);
 
 impl Timestamp {
-    /// Parses an RFC 3339-formatted string into a timestamp.
+    /// Same as [now_utc()](time::OffsetDateTime::now_utc), except it returns a
+    /// [Timestamp].
+    pub fn now_utc() -> Self {
+        OffsetDateTime::now_utc().into()
+    }
+
+    /// Parses an RFC 3339-formatted string into a [Timestamp].
     pub fn parse(string: &str) -> Result<Self, time::Error> {
         Ok(Self(OffsetDateTime::parse(string, &Rfc3339)?))
     }
@@ -95,6 +99,22 @@ impl From<OffsetDateTime> for Timestamp {
 impl From<SystemTime> for Timestamp {
     fn from(time: SystemTime) -> Self {
         Self(OffsetDateTime::from(time))
+    }
+}
+
+impl Add<Duration> for Timestamp {
+    type Output = Timestamp;
+
+    fn add(self, rhs: Duration) -> Self::Output {
+        (self.0 + rhs).into()
+    }
+}
+
+impl Sub<Duration> for Timestamp {
+    type Output = Timestamp;
+
+    fn sub(self, rhs: Duration) -> Self::Output {
+        (self.0 - rhs).into()
     }
 }
 

--- a/fiberplane-models/src/timestamps.rs
+++ b/fiberplane-models/src/timestamps.rs
@@ -10,9 +10,9 @@ use std::{
 use time::{
     ext::NumericalDuration, format_description::well_known::Rfc3339, Duration, OffsetDateTime,
 };
-use typed_builder::TypedBuilder;
 
-/// A range in time from a given timestamp (inclusive) up to another timestamp (exclusive).
+/// A range in time from a given timestamp (inclusive) up to another timestamp
+/// (exclusive).
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
@@ -22,6 +22,17 @@ use typed_builder::TypedBuilder;
 pub struct TimeRange {
     pub from: Timestamp,
     pub to: Timestamp,
+}
+
+impl TimeRange {
+    /// Creates a new time range from a start timestamp (inclusive) to an end
+    /// timestamp (exclusive).
+    pub fn new(start: Timestamp, end: Timestamp) -> Self {
+        Self {
+            from: start,
+            to: end,
+        }
+    }
 }
 
 impl From<NewTimeRange> for TimeRange {
@@ -54,11 +65,18 @@ impl From<NewTimeRange> for TimeRange {
 )]
 pub struct Timestamp(#[serde(with = "time::serde::rfc3339")] pub OffsetDateTime);
 
+impl Timestamp {
+    /// Parses an RFC 3339-formatted string into a timestamp.
+    pub fn parse(string: &str) -> Result<Self, time::Error> {
+        Ok(Self(OffsetDateTime::parse(string, &Rfc3339)?))
+    }
+}
+
 impl FromStr for Timestamp {
     type Err = time::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(OffsetDateTime::parse(s, &Rfc3339)?))
+        Self::parse(s)
     }
 }
 
@@ -129,7 +147,7 @@ impl From<TimeRange> for NewTimeRange {
 ///
 /// Relative time ranges are expanded to absolute time ranges upon instantiation
 /// of a notebook.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, TypedBuilder)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/timestamps.rs
+++ b/fiberplane-models/src/timestamps.rs
@@ -63,7 +63,7 @@ impl From<NewTimeRange> for TimeRange {
     derive(Serializable),
     fp(rust_module = "fiberplane_models::timestamps")
 )]
-pub struct Timestamp(#[serde(with = "time::serde::rfc3339")] pub OffsetDateTime);
+pub struct Timestamp(#[serde(with = "time::serde::rfc3339")] OffsetDateTime);
 
 impl Timestamp {
     /// Parses an RFC 3339-formatted string into a timestamp.

--- a/fiberplane-models/src/tokens.rs
+++ b/fiberplane-models/src/tokens.rs
@@ -2,8 +2,9 @@ use base64uuid::Base64Uuid;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use typed_builder::TypedBuilder;
+
+use crate::timestamps::Timestamp;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
 #[cfg_attr(
@@ -14,15 +15,21 @@ use typed_builder::TypedBuilder;
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct TokenSummary {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
+    #[builder(setter(into))]
     pub title: String,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(default, with = "time::serde::rfc3339::option")]
-    pub expires_at: Option<OffsetDateTime>,
+
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
+
+    #[builder(setter(into, strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<Timestamp>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),
@@ -51,11 +58,19 @@ impl NewToken {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Token {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
+    #[builder(setter(into))]
     pub title: String,
+
+    #[builder(setter(into))]
     pub token: String,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(default, with = "time::serde::rfc3339::option")]
-    pub expires_at: Option<OffsetDateTime>,
+
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
+
+    #[builder(setter(into, strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<Timestamp>,
 }

--- a/fiberplane-models/src/tokens.rs
+++ b/fiberplane-models/src/tokens.rs
@@ -24,7 +24,7 @@ pub struct TokenSummary {
     #[builder(setter(into))]
     pub created_at: Timestamp,
 
-    #[builder(setter(into, strip_option))]
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<Timestamp>,
 }
@@ -70,7 +70,7 @@ pub struct Token {
     #[builder(setter(into))]
     pub created_at: Timestamp,
 
-    #[builder(setter(into, strip_option))]
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<Timestamp>,
 }

--- a/fiberplane-models/src/users.rs
+++ b/fiberplane-models/src/users.rs
@@ -16,31 +16,20 @@ use typed_builder::TypedBuilder;
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Profile {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
-    pub email: String,
-    pub name: String,
-    pub default_workspace_id: Base64Uuid,
-    pub default_workspace_name: Name,
-    pub roles: HashMap<Base64Uuid, AuthRole>,
-}
 
-impl Profile {
-    pub fn new(
-        id: Base64Uuid,
-        email: String,
-        name: String,
-        default_workspace_id: Base64Uuid,
-        default_workspace_name: Name,
-        roles: Option<HashMap<Base64Uuid, AuthRole>>,
-    ) -> Self {
-        let roles = roles.unwrap_or_default();
-        Self {
-            id,
-            email,
-            name,
-            default_workspace_id,
-            default_workspace_name,
-            roles,
-        }
-    }
+    #[builder(setter(into))]
+    pub email: String,
+
+    #[builder(setter(into))]
+    pub name: String,
+
+    #[builder(setter(into))]
+    pub default_workspace_id: Base64Uuid,
+
+    pub default_workspace_name: Name,
+
+    #[builder(default, setter(into))]
+    pub roles: HashMap<Base64Uuid, AuthRole>,
 }

--- a/fiberplane-models/src/views.rs
+++ b/fiberplane-models/src/views.rs
@@ -100,7 +100,7 @@ pub struct NewView {
     pub sort_direction: Option<SortDirection>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),

--- a/fiberplane-models/src/views.rs
+++ b/fiberplane-models/src/views.rs
@@ -1,11 +1,11 @@
 use crate::labels::Label;
 use crate::names::Name;
 use crate::sorting::{NotebookSortFields, Pagination, SortDirection, Sorting, ViewSortFields};
+use crate::timestamps::Timestamp;
 use base64uuid::Base64Uuid;
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use typed_builder::TypedBuilder;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
@@ -17,25 +17,40 @@ use typed_builder::TypedBuilder;
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct View {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
 
     pub name: Name,
+
+    #[builder(default, setter(into))]
     pub display_name: String,
+
+    #[builder(default, setter(into))]
     pub description: String,
+
+    #[builder(default)]
     pub color: i16,
 
+    #[builder(default)]
     pub labels: Vec<Label>,
+
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub relative_time: Option<RelativeTime>,
+
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sort_by: Option<NotebookSortFields>,
+
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sort_direction: Option<SortDirection>,
 
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
+
+    #[builder(setter(into))]
+    pub updated_at: Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
@@ -58,15 +73,20 @@ pub struct ViewQuery {
 #[serde(rename_all = "camelCase")]
 pub struct NewView {
     pub name: Name,
-    #[builder(default, setter(into))]
+
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+
     #[builder(setter(into))]
     pub description: String,
+
     #[builder(default)]
     pub color: i16,
+
     #[builder(default)]
     pub labels: Vec<Label>,
+
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub relative_time: Option<RelativeTime>,
@@ -87,37 +107,43 @@ pub struct NewView {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateView {
-    #[builder(default, setter(into))]
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
-    #[builder(default, setter(into))]
+
+    #[builder(default, setter(strip_option))]
     #[serde(
         default,
         deserialize_with = "crate::deserialize_some",
         skip_serializing_if = "Option::is_none"
     )]
     pub description: Option<Option<String>>,
-    #[builder(default)]
+
+    #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color: Option<i16>,
-    #[builder(default)]
+
+    #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<Label>>,
-    #[builder(default)]
+
+    #[builder(default, setter(strip_option))]
     #[serde(
         default,
         deserialize_with = "crate::deserialize_some",
         skip_serializing_if = "Option::is_none"
     )]
     pub relative_time: Option<Option<RelativeTime>>,
-    #[builder(default)]
+
+    #[builder(default, setter(strip_option))]
     #[serde(
         default,
         deserialize_with = "crate::deserialize_some",
         skip_serializing_if = "Option::is_none"
     )]
     pub sort_by: Option<Option<NotebookSortFields>>,
-    #[builder(default)]
+
+    #[builder(default, setter(strip_option))]
     #[serde(
         default,
         deserialize_with = "crate::deserialize_some",
@@ -155,7 +181,7 @@ pub enum TimeUnit {
     Days,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq, Serialize, Copy, Clone, TypedBuilder)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Serialize, Copy, Clone)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),
@@ -171,4 +197,11 @@ pub enum TimeUnit {
 pub struct RelativeTime {
     pub unit: TimeUnit,
     pub value: i64,
+}
+
+impl RelativeTime {
+    /// Constructs a new relative time with the given `value` and `unit`.
+    pub fn new(value: i64, unit: TimeUnit) -> Self {
+        Self { unit, value }
+    }
 }

--- a/fiberplane-models/src/views.rs
+++ b/fiberplane-models/src/views.rs
@@ -78,7 +78,7 @@ pub struct NewView {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
 
-    #[builder(setter(into))]
+    #[builder(default, setter(into))]
     pub description: String,
 
     #[builder(default)]
@@ -87,13 +87,15 @@ pub struct NewView {
     #[builder(default)]
     pub labels: Vec<Label>,
 
-    #[builder(default)]
+    #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub relative_time: Option<RelativeTime>,
-    #[builder(default)]
+
+    #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sort_by: Option<NotebookSortFields>,
-    #[builder(default)]
+
+    #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sort_direction: Option<SortDirection>,
 }

--- a/fiberplane-models/src/workspaces.rs
+++ b/fiberplane-models/src/workspaces.rs
@@ -7,7 +7,6 @@ use base64uuid::Base64Uuid;
 use fp_bindgen::prelude::Serializable;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
-use time::OffsetDateTime;
 use typed_builder::TypedBuilder;
 
 /// Workspace representation.
@@ -20,14 +19,27 @@ use typed_builder::TypedBuilder;
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Workspace {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
     pub name: Name,
+
+    #[builder(setter(into))]
     pub display_name: String,
+
     #[serde(rename = "type")]
     pub ty: WorkspaceType,
+
+    #[builder(setter(into))]
     pub owner_id: Base64Uuid,
+
+    #[builder(default)]
     pub default_data_sources: SelectedDataSources,
+
+    #[builder(setter(into))]
     pub created_at: Timestamp,
+
+    #[builder(setter(into))]
     pub updated_at: Timestamp,
 }
 
@@ -45,7 +57,7 @@ pub enum WorkspaceType {
 }
 
 /// Payload to be able to invite someone to a workspace.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[cfg_attr(
     feature = "fp-bindgen",
     derive(Serializable),
@@ -55,6 +67,7 @@ pub enum WorkspaceType {
 #[serde(rename_all = "camelCase")]
 pub struct NewWorkspaceInvite {
     pub email: String,
+
     #[serde(default)]
     pub role: AuthRole,
 }
@@ -93,9 +106,12 @@ pub struct WorkspaceInviteResponse {
 #[serde(rename_all = "camelCase")]
 pub struct NewWorkspace {
     pub name: Name,
-    /// The display name of the workspace. The `name` will be used if none is provided
+
+    /// The display name of the workspace. The `name` will be used if none is provided.
     #[builder(default, setter(into, strip_option))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+
     #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_data_sources: Option<SelectedDataSources>,
@@ -124,9 +140,11 @@ pub struct UpdateWorkspace {
     #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
-    #[builder(default, setter(strip_option))]
+
+    #[builder(default, setter(into, strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner: Option<Base64Uuid>,
+
     #[builder(default, setter(strip_option))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_data_sources: Option<SelectedDataSources>,
@@ -179,13 +197,25 @@ impl Default for AuthRole {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceInvite {
+    /// ID of the invitation.
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
+    /// ID of the user who sent the invitation.
+    #[builder(setter(into))]
     pub sender: Base64Uuid,
+
+    /// Email address of the invitee.
+    #[builder(setter(into))]
     pub receiver: String,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub expires_at: OffsetDateTime,
+
+    /// Timestamp at which the invitation was created.
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
+
+    /// Timestamp at which the invitation expires.
+    #[builder(setter(into))]
+    pub expires_at: Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
@@ -197,8 +227,14 @@ pub struct WorkspaceInvite {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct Membership {
+    #[builder(setter(into))]
     pub id: Base64Uuid,
+
+    #[builder(setter(into))]
     pub email: String,
+
+    #[builder(setter(into))]
     pub name: String,
+
     pub role: AuthRole,
 }

--- a/fiberplane-provider-protocol/fiberplane-provider-runtime/src/spec/mod.rs
+++ b/fiberplane-provider-protocol/fiberplane-provider-runtime/src/spec/mod.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 use reqwest::{Client, Url};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::time::{Duration, SystemTime};
 use tracing::{debug, error, instrument, trace};
 
@@ -72,7 +72,7 @@ pub async fn make_http_request(req: HttpRequest) -> Result<HttpResponse, HttpReq
     );
 
     let status_code = response.status().as_u16();
-    let mut headers = HashMap::new();
+    let mut headers = BTreeMap::new();
     for (key, value) in response.headers().iter() {
         if let Ok(value) = value.to_str() {
             headers.insert(key.to_string(), value.to_owned());
@@ -95,7 +95,7 @@ pub async fn make_http_request(req: HttpRequest) -> Result<HttpResponse, HttpReq
     match status_code {
         _ if body.len() > MAX_HTTP_RESPONSE_SIZE => Err(HttpRequestError::ResponseTooBig),
         200..=299 => Ok(HttpResponse::builder()
-            .body(body.into())
+            .body(body)
             .headers(headers)
             .status_code(status_code)
             .build()),

--- a/fiberplane-templates/fiberplane.libsonnet
+++ b/fiberplane-templates/fiberplane.libsonnet
@@ -650,7 +650,6 @@ local cell = {
   local provider = function(intent='', title='', queryData=null, readOnly=null) {
     type: 'provider',
     output: [],
-    title: validate.string('title', title),
     intent: validate.string('intent', intent),
     queryData: validate.nullOr.string('queryData', queryData),
     readOnly: validate.nullOr.boolean('readOnly', readOnly),
@@ -661,7 +660,7 @@ local cell = {
     *
     * @function cell.provider
     * @param {string} intent - The intent of the new provider cell
-    * @param {string} title - Title for the new provider cell
+    * @param {string} title - Title for the new provider cell (deprecated)
     * @param {string} queryData - Query data that the provider will understand
     * @param {boolean} readOnly=false - Whether the cell is locked
    */

--- a/fiberplane-templates/src/convert/mod.rs
+++ b/fiberplane-templates/src/convert/mod.rs
@@ -43,7 +43,7 @@ pub fn notebook_to_template(notebook: impl Into<NewNotebook>) -> String {
     // Add all of the variables from the title and content of the notebook
     let template_function_parameters = parse_template_function_parameters(
         &notebook.title,
-        notebook.cells.iter().flat_map(|cell| cell.content()),
+        notebook.cells.iter().flat_map(Cell::content),
     );
     // If there aren't any parameters, add the title as an example of how to use template parameters
     let include_title_as_parameter = template_function_parameters.is_empty();
@@ -221,7 +221,6 @@ fn print_cell(writer: &mut CodeWriter, cell: &Cell) {
                 "loki,events",
             ];
 
-            args.push(("title", escape_string(&cell.title)));
             let cell_type = match cell.intent.as_str() {
                 intent if INTENTS_WITH_TEMPLATES_HELPERS.contains(&intent) => {
                     if let Some(query) = decode_provider_cell_query_data(&cell.query_data) {

--- a/fiberplane-templates/src/convert/mod.rs
+++ b/fiberplane-templates/src/convert/mod.rs
@@ -9,7 +9,7 @@ use once_cell::sync::Lazy;
 use percent_encoding::percent_decode_str;
 use regex::Regex;
 use std::{collections::BTreeSet, fmt::Write};
-use time::{format_description::well_known::Rfc3339, Duration};
+use time::Duration;
 use tracing::warn;
 
 mod code_writer;
@@ -370,9 +370,7 @@ fn format_content(content: &str, formatting: &Formatting) -> String {
                 index += char_count(&mention.name) + 1;
             }
             Annotation::Timestamp { timestamp } => {
-                let formatted = timestamp
-                    .format(&Rfc3339)
-                    .expect("Invalid timestamp format");
+                let formatted = timestamp.to_string();
                 write!(output, "fmt.timestamp('{formatted}'), ")
                     .expect("Cannot write timestamp instruction");
                 index += char_count(&formatted);

--- a/fiberplane-templates/src/convert/tests.rs
+++ b/fiberplane-templates/src/convert/tests.rs
@@ -1,8 +1,7 @@
+use super::*;
 use fiberplane_models::formatting::Mention;
 use fiberplane_models::notebooks::{DividerCell, Label, ProviderCell, TextCell};
-use time::OffsetDateTime;
-
-use super::*;
+use fiberplane_models::timestamps::Timestamp;
 
 #[test]
 fn formatting_basic() {
@@ -86,7 +85,7 @@ fn format_timestamp() {
     let formatting = vec![AnnotationWithOffset::new(
         3,
         Annotation::Timestamp {
-            timestamp: OffsetDateTime::parse("2020-01-01T00:00:00Z", &Rfc3339).unwrap(),
+            timestamp: Timestamp::parse("2020-01-01T00:00:00Z").unwrap(),
         },
     )];
     let actual = format_content(content, &formatting);
@@ -167,7 +166,6 @@ fn print_cell_handles_formatted_unicode() {
 fn decodes_well_known_provider_cell_data() {
     let mut writer = CodeWriter::new();
     let cell = Cell::Provider(ProviderCell::builder()
-                              .title("".to_string())
         .intent("prometheus,timeseries".to_string())
         .query_data("application/x-www-form-urlencoded,query=apiserver_audit_event_total%7Bjob%3D%22test%22%7D".to_string())
                               .id("c1")
@@ -177,10 +175,7 @@ fn decodes_well_known_provider_cell_data() {
     print_cell(&mut writer, &cell);
     assert_eq!(
         writer.to_string(),
-        "c.prometheus(
-  title='',
-  content='apiserver_audit_event_total{job=\"test\"}',
-),
+        "c.prometheus('apiserver_audit_event_total{job=\"test\"}'),
 "
     );
 }
@@ -189,7 +184,6 @@ fn decodes_well_known_provider_cell_data() {
 fn decodes_arbitrary_provider_cell_data() {
     let mut writer = CodeWriter::new();
     let cell = Cell::Provider(ProviderCell::builder()
-                              .title("".to_string())
         .intent("cloudwatch,x-list-metrics".to_string())
         .query_data("application/x-www-form-urlencoded,query=CPUUtil&tag_name=Environment&tag_values=prod+production".to_string())
                               .id("c1")
@@ -200,7 +194,6 @@ fn decodes_arbitrary_provider_cell_data() {
     assert_eq!(
         writer.to_string(),
         "c.provider(
-  title='',
   intent='cloudwatch,x-list-metrics',
   queryData='application/x-www-form-urlencoded,query=CPUUtil&tag_name=Environment&tag_values=prod+production',
 ),

--- a/fiberplane-templates/tests/test.rs
+++ b/fiberplane-templates/tests/test.rs
@@ -18,10 +18,7 @@ fn mustache_substitution_with_formatting() {
                 ])
                 .build(),
         )])
-        .selected_data_sources(Default::default())
-        .time_range(NewTimeRange::Relative(
-            RelativeTimeRange::builder().minutes(-60).build(),
-        ))
+        .time_range(NewTimeRange::Relative(RelativeTimeRange::from_minutes(-60)))
         .build();
     let template = notebook_to_template(notebook);
     assert!(template.contains("fmt.bold([personName, ', great to have you'])"),);

--- a/scripts/generate_api_client.sh
+++ b/scripts/generate_api_client.sh
@@ -9,9 +9,7 @@ REPO="https://github.com/fiberplane/fiberplane"
 LICENSE="MIT OR Apache-2.0"
 README="README.md"
 
-# https://stackoverflow.com/a/23930212/11494565
-read -r -d '' MODELS << EOM
-fiberplane_models::notebooks::*;
+MODELS="fiberplane_models::notebooks::*;
 fiberplane_models::notebooks::operations::*;
 fiberplane_models::blobs::*;
 fiberplane_models::comments::*;
@@ -31,8 +29,7 @@ fiberplane_models::timestamps::*;
 fiberplane_models::tokens::*;
 fiberplane_models::users::*;
 fiberplane_models::views::*;
-fiberplane_models::workspaces::*
-EOM
+fiberplane_models::workspaces::*"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
@@ -84,4 +81,4 @@ fi
 cd "$SCRIPT_DIR/../fiberplane-api-client"
 cargo fmt -p fiberplane-api-client
 
-ln ../scripts/fiberplane-api-client-template/* .
+ln -s ../scripts/fiberplane-api-client-template/* .


### PR DESCRIPTION
# Description

As promised, this PR contains our spring cleaning of types to prepare us for getting our open-source packages out of beta.

This includes:

* When a type has a (convenience) constructor, don't also derive `TypedBuilder` so it's clear which constructor to use.
Making `#[builder]` setters more consistent with regards to the arguments they accept.
* Using our `Timestamp` type consistently instead of mixing its usage with `OffsetDateTime`. `Timestamp` already wraps `OffsetDateTime` while making sure the serialization is set up correctly, which saves us a whole bunch of annotations elsewhere.
* Making sure `None` values are consistently skipped during serialization, which also makes generated TypeScript types more consistent.
* Adding field docs. I definitely won't be able to cover everything here, so please keep in mind to document fields when you add or update them. When adding fields or types, why are you adding them? How is the type/field supposed to be used? What is the impact of setting a field? Answering those questions in the documentation can add a lot of meaningful context.
* Dropped the `title` field from `ProviderCell`.
* Updated the PR checklist.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- ~~[ ] The changes have been tested to be backwards compatible.~~ **This PR contains backwards incompatible changes!** Existing notebooks, templates and providers should still work. Source code for providers may need to be updated to the latest PDK to compile again though.
- [x] The OpenAPI schema and generated client have been updated: https://github.com/fiberplane/fp-openapi-rust-gen/pull/25
- ~~[ ] New models module has been added to API generator script~~
- [x] PR for API is ready and reviewed: https://github.com/fiberplane/api/pull/636
- [x] PR for Studio is ready and reviewed: https://github.com/fiberplane/studio/pull/1478
- [x] PR for Providers is ready and reviewer: https://github.com/fiberplane/providers/pull/32
- [x] PR for CLI is ready and reviewed: https://github.com/fiberplane/fp/pull/235
- [x] PR for FPD is ready and reviewed: https://github.com/fiberplane/fpd/pull/136
- [x] The CHANGELOG(s) are updated.

When adding new operation types:

- [x] PR for fiberplane-ot is ready and reviewed: https://github.com/fiberplane/fiberplane-ot/pull/13

After merging, please merge related PRs ASAP, so others don't get blocked.
