### PR TITLE
Fix alpha version crates_io parsing

### DIFF
--- a/fiberplane-ci/src/utils/crates.rs
+++ b/fiberplane-ci/src/utils/crates.rs
@@ -66,9 +66,8 @@ pub async fn get_previous_alpha_version(
 ///
 /// Notably, this _includes_ the yanked versions.
 ///
-/// There is no guarantee on the order in the resulting list, it is most
-/// likely to be ordered from older publication date to newest publication date.
-/// Note that "yanking" a version is a publication event, and might change the ordering.
+/// The versions are sorted from smallest semver-wise (0.0.0-alpha.0) to most
+/// recent semver-wise (9999.9999.9999).
 async fn get_published_versions(index_url: &str, crate_name: &str) -> Result<Vec<String>> {
     let index_url = format!("{index_url}/{}", index_url_path(crate_name));
     let client = Client::new();
@@ -79,7 +78,7 @@ async fn get_published_versions(index_url: &str, crate_name: &str) -> Result<Vec
         .await?;
     let response_text = response.text().await?;
 
-    response_text
+    let mut versions = response_text
         .split('\n')
         .map(str::trim)
         .filter(|line| !line.is_empty())
@@ -90,7 +89,11 @@ async fn get_published_versions(index_url: &str, crate_name: &str) -> Result<Vec
                 Err(error.into())
             }
         })
-        .collect()
+        .collect::<Result<Vec<String>>>()?;
+
+    sort_versions(&mut versions);
+
+    Ok(versions)
 }
 
 /// Helper for generating index path to crates
@@ -122,6 +125,95 @@ pub async fn is_published(index_url: &str, crate_name: &str, version: &str) -> R
     Ok(versions.iter().any(|published| published == version))
 }
 
+fn sort_versions(versions: &mut [String]) {
+    versions.sort_by(|lhs, rhs| {
+        let (l_major, l_minor, l_patch, l_meta) =
+            parse_version(lhs).expect("crates-io returns valid version numbers.");
+        let (r_major, r_minor, r_patch, r_meta) =
+            parse_version(rhs).expect("crates-io returns valid version numbers.");
+        if l_major != r_major {
+            return l_major.cmp(&r_major);
+        }
+        if l_minor != r_minor {
+            return l_minor.cmp(&r_minor);
+        }
+        if l_patch != r_patch {
+            return l_patch.cmp(&r_patch);
+        }
+        match (l_meta, r_meta) {
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+            (Some(l_meta), Some(r_meta)) => cmp_prereleases(l_meta, r_meta),
+        }
+    });
+}
+
+// NOTE: we do not rely on a crate like semver to do the comparison because we
+// have non-semver versions like '1.0.0-beta.2-alpha.3' (with 2 dashes) that
+// semver crate cannot sort as we want out of the box.
+fn cmp_prereleases(lhs: &str, rhs: &str) -> std::cmp::Ordering {
+    assert!(lhs.split('-').count() <= 2, "Comparing prerelease versions for ordering only works when prereleases have at most 1 '-'; {lhs:?} is invalid");
+    assert!(rhs.split('-').count() <= 2, "Comparing prerelease versions for ordering only works when prereleases have at most 1 '-'; {rhs:?} is invalid");
+
+    /// Computes ordering between components like 'alpha.2' and 'beta.5',
+    /// making sure that 'alpha.14' < 'alpha.3'
+    fn cmp_prerelease_sections(lhs: &str, rhs: &str) -> std::cmp::Ordering {
+        match (lhs.split_once('.'), rhs.split_once('.')) {
+            (None, None) => lhs.cmp(rhs),
+            (None, Some((r_first, _r_count))) => {
+                if lhs == r_first {
+                    std::cmp::Ordering::Less
+                } else {
+                    lhs.cmp(r_first)
+                }
+            }
+            (Some((l_first, _l_count)), None) => {
+                if l_first == rhs {
+                    std::cmp::Ordering::Greater
+                } else {
+                    l_first.cmp(rhs)
+                }
+            }
+            (Some((l_first, l_count)), Some((r_first, r_count))) => {
+                if l_first != r_first {
+                    l_first.cmp(r_first)
+                } else {
+                    l_count
+                        .parse::<u32>()
+                        .unwrap()
+                        .cmp(&r_count.parse::<u32>().unwrap())
+                }
+            }
+        }
+    }
+
+    match (lhs.split_once('-'), rhs.split_once('-')) {
+        (None, None) => lhs.cmp(rhs),
+        (None, Some((r_first, _r_second))) => {
+            if lhs == r_first {
+                std::cmp::Ordering::Greater
+            } else {
+                cmp_prerelease_sections(lhs, r_first)
+            }
+        }
+        (Some((l_first, _l_second)), None) => {
+            if rhs == l_first {
+                std::cmp::Ordering::Less
+            } else {
+                cmp_prerelease_sections(l_first, rhs)
+            }
+        }
+        (Some((l_first, l_second)), Some((r_first, r_second))) => {
+            if l_first != r_first {
+                cmp_prerelease_sections(l_first, r_first)
+            } else {
+                cmp_prerelease_sections(l_second, r_second)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -132,5 +224,35 @@ mod tests {
         assert_eq!(&index_url_path("fib"), "3/f/fib");
         assert_eq!(&index_url_path("fi"), "2/fi");
         assert_eq!(&index_url_path("f"), "1/f");
+    }
+
+    #[test]
+    fn test_versions_sort() {
+        let mut start = vec![
+            "1.1.0".to_string(),
+            "1.1.1".to_string(),
+            "1.0.1".to_string(),
+            "0.1.0".to_string(),
+            "1.1.0-alpha.12".to_string(),
+            "1.1.0-beta.1".to_string(),
+            "1.1.0-beta.1-alpha.2".to_string(),
+            "1.1.0-alpha.2".to_string(),
+        ];
+
+        sort_versions(&mut start);
+
+        assert_eq!(
+            start,
+            vec![
+                "0.1.0".to_string(),
+                "1.0.1".to_string(),
+                "1.1.0-alpha.12".to_string(),
+                "1.1.0-alpha.2".to_string(),
+                "1.1.0-beta.1-alpha.2".to_string(),
+                "1.1.0-beta.1".to_string(),
+                "1.1.0".to_string(),
+                "1.1.1".to_string(),
+            ]
+        );
     }
 }

--- a/fiberplane-ci/src/utils/crates.rs
+++ b/fiberplane-ci/src/utils/crates.rs
@@ -51,7 +51,13 @@ pub async fn get_previous_alpha_version(
         .into_iter()
         .rev()
         .find(|version| match parse_version(version) {
-            Ok((_, _, _, Some(suffix))) => suffix.starts_with("alpha-"),
+            Ok((_, _, _, Some(suffix))) => {
+                // suffix can sometimes be '-beta.12-alpha.10'
+                match suffix.rsplit_once('-') {
+                    Some((_beta_prefix, alpha_suffix)) => alpha_suffix.starts_with("alpha."),
+                    None => suffix.starts_with("alpha."),
+                }
+            }
             _ => false,
         }))
 }
@@ -60,7 +66,9 @@ pub async fn get_previous_alpha_version(
 ///
 /// Notably, this _includes_ the yanked versions.
 ///
-/// Returned versions are ordered from oldest to newest.
+/// There is no guarantee on the order in the resulting list, it is most
+/// likely to be ordered from older publication date to newest publication date.
+/// Note that "yanking" a version is a publication event, and might change the ordering.
 async fn get_published_versions(index_url: &str, crate_name: &str) -> Result<Vec<String>> {
     let index_url = format!("{index_url}/{}", index_url_path(crate_name));
     let client = Client::new();
@@ -85,6 +93,13 @@ async fn get_published_versions(index_url: &str, crate_name: &str) -> Result<Vec
         .collect()
 }
 
+/// Helper for generating index path to crates
+/// ```rust,ignore
+/// assert_eq!(&index_url_path("fiberplane"), "fi/be/fiberplane");
+/// assert_eq!(&index_url_path("fib"), "3/f/fib");
+/// assert_eq!(&index_url_path("fi"), "2/fi");
+/// assert_eq!(&index_url_path("f"), "1/f");
+/// ```
 fn index_url_path(crate_name: &str) -> String {
     match crate_name.len() {
         1 => format!("1/{crate_name}"),
@@ -105,4 +120,17 @@ fn index_url_path(crate_name: &str) -> String {
 pub async fn is_published(index_url: &str, crate_name: &str, version: &str) -> Result<bool> {
     let versions = get_published_versions(index_url, crate_name).await?;
     Ok(versions.iter().any(|published| published == version))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_index_path() {
+        assert_eq!(&index_url_path("fiberplane"), "fi/be/fiberplane");
+        assert_eq!(&index_url_path("fib"), "3/f/fib");
+        assert_eq!(&index_url_path("fi"), "2/fi");
+        assert_eq!(&index_url_path("f"), "1/f");
+    }
 }

--- a/fiberplane-ci/src/utils/versions.rs
+++ b/fiberplane-ci/src/utils/versions.rs
@@ -76,16 +76,15 @@ pub fn matches_base_version(version: &str, base_version: &str) -> bool {
 /// ```rust
 /// use fiberplane_ci::utils::parse_suffix;
 ///
-/// assert_eq!(parse_suffix("alpha.3").unwrap(), ("alpha.", 3));
-/// assert_eq!(parse_suffix("beta.2-alpha.1").unwrap(), ("beta.2-alpha.", 1));
+/// assert_eq!(parse_suffix("alpha.3").unwrap(), ("alpha", 3));
+/// assert_eq!(parse_suffix("beta.2-alpha.1").unwrap(), ("beta.2-alpha", 1));
 /// ```
 pub fn parse_suffix(suffix: &str) -> Result<(&str, u16)> {
-    let Some(last_dot_position) = suffix.chars().rev().position(|char| char == '.') else {
+    let Some((prefix, last_count)) = suffix.rsplit_once('.') else {
         bail!("Suffix contains no dot to mark its count");
     };
-    let count_index = suffix.len() - last_dot_position;
-    let count: u16 = suffix[count_index..].parse()?;
-    Ok((&suffix[..count_index], count))
+    let count: u16 = last_count.parse()?;
+    Ok((prefix, count))
 }
 
 /// Parses a version string into its major, minor and patch components, with an


### PR DESCRIPTION
This should fix xtask trying to push again on an existing alpha version

# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context.

~~Fixes FP-(issue)~~

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [x] ~~The changes have been tested to be backwards compatible.~~
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] ~~New models module has been added to API generator script.~~
- [x] ~~New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [x] ~~The CHANGELOG is updated.~~

> Please link any related PRs in other repositories that depend on this:

<!-- * API: https://github.com/fiberplane/api/pull/XXX -->
<!-- * Studio: https://github.com/fiberplane/studio/pull/XXX  -->
<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * OT: https://github.com/fiberplane/fiberplane-ot/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
