### PR TITLE
Upgrade to fp-bindgen v3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ rust-version = "1.64"
 [workspace.dependencies]
 base64uuid = { version = "1.0.0", path = "base64uuid", default-features = false }
 bytes = { version = "1", features = ["serde"] }
-fp-bindgen = { version = "3.0.0-beta.1" }
-fp-bindgen-support = { version = "3.0.0-beta.1" }
+fp-bindgen = { version = "3.0.0" }
+fp-bindgen-support = { version = "3.0.0" }
 fiberplane = { version = "1.0.0-beta.1", path = "fiberplane" }
 fiberplane-api-client = { version = "1.0.0-beta.1", path = "fiberplane-api-client" }
 fiberplane-ci = { version = "0.1.0", path = "fiberplane-ci" }
@@ -56,7 +56,7 @@ vergen = { version = "7.4.2", default-features = false, features = [
 ] }
 
 [patch.crates-io]
-#fp-bindgen = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "main" }
-#fp-bindgen-support = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "main" }
+fp-bindgen = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "release-3.0.0" }
+fp-bindgen-support = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "release-3.0.0" }
 #fp-bindgen = { path = "../fp-bindgen/fp-bindgen" }
 #fp-bindgen-support = { path = "../fp-bindgen/fp-bindgen-support" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ vergen = { version = "7.4.2", default-features = false, features = [
 ] }
 
 [patch.crates-io]
-fp-bindgen = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "release-3.0.0" }
-fp-bindgen-support = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "release-3.0.0" }
+#fp-bindgen = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "release-3.0.0" }
+#fp-bindgen-support = { git = "ssh://git@github.com/fiberplane/fp-bindgen.git", branch = "release-3.0.0" }
 #fp-bindgen = { path = "../fp-bindgen/fp-bindgen" }
 #fp-bindgen-support = { path = "../fp-bindgen/fp-bindgen-support" }

--- a/fiberplane-provider-protocol/fiberplane-provider-bindings/Cargo.toml
+++ b/fiberplane-provider-protocol/fiberplane-provider-bindings/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fiberplane-provider-bindings"
+version = "2.0.0-beta.2"
+authors = { workspace = true }
+edition = "2018"
 description = "Fiberplane Provider protocol bindings"
 readme = "README.md"
-version = "2.0.0-beta.2"
-authors = ["Fiberplane <info@fiberplane.com>"]
-edition = "2018"
 license = { workspace = true }
 
 [dependencies]

--- a/fiberplane-provider-protocol/fiberplane-provider-bindings/src/types.rs
+++ b/fiberplane-provider-protocol/fiberplane-provider-bindings/src/types.rs
@@ -1,4 +1,4 @@
-#![allow(unused_imports)]
+#![allow(dead_code, unused_imports)]
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/fiberplane-provider-protocol/fiberplane-provider-runtime/Cargo.toml
+++ b/fiberplane-provider-protocol/fiberplane-provider-runtime/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 bytes = { workspace = true }
-fp-bindgen-support = { workspace = true, features = ["async", "host"] }
+fp-bindgen-support = { workspace = true, features = ["async", "wasmer2_host"] }
 fiberplane-models = { workspace = true }
 rand = "0.8.0"
 reqwest = { version = "0.11.4", default-features = false, features = [

--- a/fiberplane-provider-protocol/fiberplane-provider-runtime/src/spec/types.rs
+++ b/fiberplane-provider-protocol/fiberplane-provider-runtime/src/spec/types.rs
@@ -1,4 +1,4 @@
-#![allow(unused_imports)]
+#![allow(dead_code, unused_imports)]
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/fiberplane-provider-protocol/src/main.rs
+++ b/fiberplane-provider-protocol/src/main.rs
@@ -115,12 +115,17 @@ fn main() {
 
         let path = "./fiberplane-provider-bindings";
         fp_bindgen!(BindingConfig {
-            bindings_type: BindingsType::RustPlugin(RustPluginConfig {
-                name: "fiberplane-provider-bindings",
-                authors: r#"["Fiberplane <info@fiberplane.com>"]"#,
-                version: "2.0.0-beta.2",
-                dependencies,
-            }),
+            bindings_type: BindingsType::RustPlugin(
+                RustPluginConfig::builder()
+                    .name("fiberplane-provider-bindings")
+                    .description("Fiberplane Provider protocol bindings")
+                    .readme("README.md")
+                    .version("2.0.0-beta.2")
+                    .authors(RustPluginConfigValue::Workspace)
+                    .license(RustPluginConfigValue::Workspace)
+                    .dependencies(dependencies)
+                    .build()
+            ),
             path,
         });
         println!("Rust plugin bindings written to `{path}/`.");
@@ -129,7 +134,7 @@ fn main() {
     {
         let path = "./fiberplane-provider-runtime/src/spec";
         fp_bindgen!(BindingConfig {
-            bindings_type: BindingsType::RustWasmerRuntime,
+            bindings_type: BindingsType::RustWasmer2Runtime,
             path,
         });
         println!("Rust Wasmer runtime bindings written to `{path}/`.");
@@ -138,8 +143,8 @@ fn main() {
     {
         let path = "./ts-runtime";
         fp_bindgen!(BindingConfig {
-            bindings_type: BindingsType::TsRuntimeWithExtendedConfig(
-                TsExtendedRuntimeConfig::new().with_raw_export_wrappers()
+            bindings_type: BindingsType::TsRuntime(
+                TsRuntimeConfig::new().with_raw_export_wrappers()
             ),
             path,
         });

--- a/fiberplane-provider-protocol/ts-runtime/types.ts
+++ b/fiberplane-provider-protocol/ts-runtime/types.ts
@@ -20,13 +20,13 @@ export type Annotation =
     | { type: "end_italics" }
     | { type: "start_link"; url: string }
     | { type: "end_link" }
-    | ({ type: "mention" } & Mention)
+    | { type: "mention" } & Mention
     | { type: "timestamp"; timestamp: Timestamp }
     | { type: "start_strikethrough" }
     | { type: "end_strikethrough" }
     | { type: "start_underline" }
     | { type: "end_underline" }
-    | ({ type: "label" } & Label);
+    | { type: "label" } & Label;
 
 /**
  * An annotation at a specific offset in the text. Offsets are always
@@ -217,19 +217,19 @@ export type Blob = {
  * Representation of a single notebook cell.
  */
 export type Cell =
-    | ({ type: "checkbox" } & CheckboxCell)
-    | ({ type: "code" } & CodeCell)
-    | ({ type: "discussion" } & DiscussionCell)
-    | ({ type: "divider" } & DividerCell)
-    | ({ type: "graph" } & GraphCell)
-    | ({ type: "heading" } & HeadingCell)
-    | ({ type: "image" } & ImageCell)
-    | ({ type: "list_item" } & ListItemCell)
-    | ({ type: "log" } & LogCell)
-    | ({ type: "provider" } & ProviderCell)
-    | ({ type: "table" } & TableCell)
-    | ({ type: "timeline" } & TimelineCell)
-    | ({ type: "text" } & TextCell);
+    | { type: "checkbox" } & CheckboxCell
+    | { type: "code" } & CodeCell
+    | { type: "discussion" } & DiscussionCell
+    | { type: "divider" } & DividerCell
+    | { type: "graph" } & GraphCell
+    | { type: "heading" } & HeadingCell
+    | { type: "image" } & ImageCell
+    | { type: "list_item" } & ListItemCell
+    | { type: "log" } & LogCell
+    | { type: "provider" } & ProviderCell
+    | { type: "table" } & TableCell
+    | { type: "timeline" } & TimelineCell
+    | { type: "text" } & TextCell;
 
 export type CheckboxCell = {
     id: string;
@@ -300,10 +300,10 @@ export type CodeCell = {
 };
 
 export type ConfigField =
-    | ({ type: "checkbox" } & CheckboxField)
-    | ({ type: "integer" } & IntegerField)
-    | ({ type: "select" } & SelectField)
-    | ({ type: "text" } & TextField);
+    | { type: "checkbox" } & CheckboxField
+    | { type: "integer" } & IntegerField
+    | { type: "select" } & SelectField
+    | { type: "text" } & TextField;
 
 export type ConfigSchema = Array<ConfigField>;
 
@@ -370,14 +370,14 @@ export type EncodedBlob = {
 export type Error =
     | { type: "unsupported_request" }
     | {
-          type: "validation_error";
+        type: "validation_error";
 
-          /**
-             * List of errors, so all fields that failed validation can
-             * be highlighted at once.
-             */
-          errors: Array<ValidationError>;
-      }
+        /**
+         * List of errors, so all fields that failed validation can
+         * be highlighted at once.
+         */
+        errors: Array<ValidationError>;
+    }
     | { type: "http"; error: HttpRequestError }
     | { type: "data"; message: string }
     | { type: "deserialization"; message: string }
@@ -429,7 +429,9 @@ export type GraphCell = {
     stackingType: StackingType;
 };
 
-export type GraphType = "bar" | "line";
+export type GraphType =
+    | "bar"
+    | "line";
 
 export type HeadingCell = {
     id: string;
@@ -443,7 +445,10 @@ export type HeadingCell = {
     readOnly?: boolean;
 };
 
-export type HeadingType = "h1" | "h2" | "h3";
+export type HeadingType =
+    | "h1"
+    | "h2"
+    | "h3";
 
 /**
  * HTTP request options.
@@ -625,7 +630,9 @@ export type ListItemCell = {
     startNumber?: number;
 };
 
-export type ListType = "ordered" | "unordered";
+export type ListType =
+    | "ordered"
+    | "unordered";
 
 export type LogCell = {
     id: string;
@@ -659,7 +666,10 @@ export type LogRecordIndex = {
     recordIndex: number;
 };
 
-export type LogVisibilityFilter = "all" | "selected" | "highlighted";
+export type LogVisibilityFilter =
+    | "all"
+    | "selected"
+    | "highlighted";
 
 /**
  * Annotation for the mention of a user.
@@ -825,14 +835,14 @@ export type ProviderStatus = {
 };
 
 export type QueryField =
-    | ({ type: "array" } & ArrayField)
-    | ({ type: "checkbox" } & CheckboxField)
-    | ({ type: "date_time_range" } & DateTimeRangeField)
-    | ({ type: "file" } & FileField)
-    | ({ type: "label" } & LabelField)
-    | ({ type: "integer" } & IntegerField)
-    | ({ type: "select" } & SelectField)
-    | ({ type: "text" } & TextField);
+    | { type: "array" } & ArrayField
+    | { type: "checkbox" } & CheckboxField
+    | { type: "date_time_range" } & DateTimeRangeField
+    | { type: "file" } & FileField
+    | { type: "label" } & LabelField
+    | { type: "integer" } & IntegerField
+    | { type: "select" } & SelectField
+    | { type: "text" } & TextField;
 
 export type QuerySchema = Array<QueryField>;
 
@@ -905,7 +915,10 @@ export type SelectField = {
     supportsSuggestions: boolean;
 };
 
-export type StackingType = "none" | "stacked" | "percentage";
+export type StackingType =
+    | "none"
+    | "stacked"
+    | "percentage";
 
 /**
  * A suggestion for a provider's auto-suggest functionality.
@@ -981,7 +994,9 @@ export type TableCell = {
     rows?: Array<TableRowData>;
 };
 
-export type TableCellValue = { type: "empty" } | { type: "cell"; cell: Cell };
+export type TableCellValue =
+    | { type: "empty" }
+    | { type: "cell"; cell: Cell };
 
 export type TableColumnDefinition = {
     /**


### PR DESCRIPTION
# Description

Upgrades to fp-bindgen v3.0.0: https://github.com/fiberplane/fp-bindgen/pull/193

Please review the fp-bindgen release PR as well. Once that one is merged and published, I'll remove the patches here and merge this one, followed by any downstream ones.

# Checklist

Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.

- [ ] The changes have been tested to be backwards compatible.
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] New models module has been added to API generator script.~~
- ~~[ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [ ] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * API: https://github.com/fiberplane/api/pull/XXX -->
* Studio: https://github.com/fiberplane/studio/pull/1503
* Providers: https://github.com/fiberplane/providers/pull/40
* Daemon: https://github.com/fiberplane/fpd/pull/139
* FP: https://github.com/fiberplane/fp/pull/240
* OT: https://github.com/fiberplane/fiberplane-ot/pull/15

After merging, please merge related PRs ASAP, so others don't get blocked.
