### PR TITLE
 extend webhook models with new things specified in design 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ changes if the major version hasn't changed.
   query schemas that include rows/records of arbitrary data. (#39)
 - `fiberplane-models`: Added various structures for webhooks. (#41)
 - `fiberplane-api-client`: Added new webhook endpoints. (#41)
+- `fiberplane-models`: Added new field `successful` to `Webhook` and added new field `enabled` to `NewWebhook` struct (#54)
 
 ### Changed
 

--- a/fiberplane-models/src/webhooks.rs
+++ b/fiberplane-models/src/webhooks.rs
@@ -86,6 +86,9 @@ pub struct Webhook {
     #[builder(default)]
     pub enabled: bool,
 
+    #[builder(default)]
+    successful: bool,
+
     #[builder(default, setter(strip_option, into))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub created_by: Option<Base64Uuid>,
@@ -106,7 +109,11 @@ pub struct Webhook {
 pub struct NewWebhook {
     #[builder(setter(into))]
     pub endpoint: String,
+
     pub events: Vec<WebhookCategory>,
+
+    #[builder(default)]
+    pub enabled: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]

--- a/fiberplane-models/src/webhooks.rs
+++ b/fiberplane-models/src/webhooks.rs
@@ -86,6 +86,7 @@ pub struct Webhook {
     #[builder(default)]
     pub enabled: bool,
 
+    /// Whenever the last delivery was successful
     #[builder(default)]
     pub successful: bool,
 

--- a/fiberplane-models/src/webhooks.rs
+++ b/fiberplane-models/src/webhooks.rs
@@ -87,7 +87,7 @@ pub struct Webhook {
     pub enabled: bool,
 
     #[builder(default)]
-    successful: bool,
+    pub successful: bool,
 
     #[builder(default, setter(strip_option, into))]
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/fiberplane-models/src/webhooks.rs
+++ b/fiberplane-models/src/webhooks.rs
@@ -86,7 +86,7 @@ pub struct Webhook {
     #[builder(default)]
     pub enabled: bool,
 
-    /// Whenever the last delivery was successful
+    /// Whether the last delivery was successful
     #[builder(default)]
     pub successful: bool,
 

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2163,7 +2163,7 @@ components:
         enabled:
           type: boolean
         successful:
-          description: Whenever the last delivery (which upon create or update is the `ping` payload) was successful
+          description: Whenever the last delivery was successful
           type: boolean
         createdBy:
           type: string

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2163,7 +2163,7 @@ components:
         enabled:
           type: boolean
         successful:
-          description: Whenever the last delivery was successful
+          description: Whether the last delivery was successful
           type: boolean
         createdBy:
           type: string

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2141,6 +2141,7 @@ components:
         - endpoint
         - events
         - enabled
+        - successful
         - createdAt
         - updatedAt
       properties:
@@ -2161,6 +2162,9 @@ components:
           format: password
         enabled:
           type: boolean
+        successful:
+          description: Whenever the last delivery (which upon create or update is the `ping` payload) was successful
+          type: boolean
         createdBy:
           type: string
           format: base64uuid
@@ -2180,6 +2184,7 @@ components:
       required:
         - endpoint
         - events
+        - enabled
       properties:
         endpoint:
           type: string
@@ -2187,6 +2192,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/webhook_events"
+        enabled:
+          type: boolean
     update_webhook:
       type: object
       properties:


### PR DESCRIPTION
# Description

fixes FP-3201
fixes FP-3200

# Checklist

- [x] The changes have been tested to be backwards compatible.
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] ~~New models module has been added to api generator xtask~~
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

* API: https://github.com/fiberplane/api/pull/651
* FP: https://github.com/fiberplane/fp/pull/242

After merging, please merge related PRs ASAP, so others don't get blocked.
