### PR TITLE
Bump octocrab to v0.23

### DIFF
--- a/fiberplane-ci/Cargo.toml
+++ b/fiberplane-ci/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1"
 async-trait = "0.1"
 clap = { version = "4", features = ["derive", "env"] }
 duct = "0.13"
-octocrab = { version = "0.18", default-features = false, features = ["rustls"] }
+octocrab = { version = "0.23", default-features = false, features = ["rustls"] }
 reqwest = { version = "0.11", default-features = false, features = [
     "gzip",
     "json",


### PR DESCRIPTION
# Description

Bumps Octocrab to v0.23, because v0.18 still pulled in `hyperx` which looks to be unmaintained now.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [ ] The changes have been tested to be backwards compatible.
- [ ] The OpenAPI schema and generated client have been updated.
- [ ] New models module has been added to api generator xtask
- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [ ] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * API: https://github.com/fiberplane/api/pull/XXX -->
<!-- * Studio: https://github.com/fiberplane/studio/pull/XXX  -->
<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * OT: https://github.com/fiberplane/fiberplane-ot/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
