### PR TITLE
Release fix

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,12 +2,20 @@
 # dependent on this crate
 * @fiberplane/api-devs @fiberplane/studio-devs
 
+# API devs own the API client and the API generator
+/fiberplane-api-client/ @fiberplane/api-devs
+/fiberplane-openapi-rust-gen/ @fiberplane/api-devs
+
 # Provider specific stuff is owned by the plugin team
 /fiberplane-provider-protocol/ @fiberplane/plugin-devs
-/providers/ @fiberplane/plugin-devs
 
 # Templates are owned by the template team
 /fiberplane-templates/ @fiberplane/template-devs
 
 # Charts is owned by the Studio team
 /fiberplane-charts/ @fiberplane/studio-devs
+
+# CI stuff is owned by the infrastructure team
+.github @fiberplane/infrastructure-devs
+/fiberplane-ci/ @fiberplane/infrastructure-devs
+/xtask/ @fiberplane/infrastructure-devs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,11 +21,9 @@ indicate they don't apply.
 
 > Please link any related PRs in other repositories that depend on this:
 
-<!-- * API: https://github.com/fiberplane/api/pull/XXX -->
-<!-- * Studio: https://github.com/fiberplane/studio/pull/XXX  -->
 <!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
 <!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
 <!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
-<!-- * OT: https://github.com/fiberplane/fiberplane-ot/pull/XXX -->
+<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->
 
 After merging, please merge related PRs ASAP, so others don't get blocked.

--- a/fiberplane-ci/src/utils/git.rs
+++ b/fiberplane-ci/src/utils/git.rs
@@ -2,45 +2,6 @@ use anyhow::{bail, Result};
 use duct::cmd;
 use std::str::Utf8Error;
 
-/// Returns whether a path in the repo has changed since the given commit.
-pub fn did_change(repo_dir: &str, path: &str, since_commit: &str) -> Result<bool> {
-    let output = cmd!(
-        "git",
-        "diff",
-        "--quiet",
-        "--ignore-space-change",
-        "HEAD",
-        since_commit,
-        "--",
-        path
-    )
-    .dir(repo_dir)
-    .unchecked()
-    .run()?;
-    match output.status.code() {
-        Some(1) => Ok(true),
-        Some(0) => Ok(false),
-        Some(code) => bail!("Unexpected exit code ({code}) from `git diff`"),
-        None => bail!("`git diff` terminated unexpectedly"),
-    }
-}
-
-/// Returns whether a path in the repo has changed since the previous release
-/// branch was created.
-///
-/// If no previous release branch can be found at all, we consider that a new
-/// release is in order, so this function will return `true` in that case.
-pub fn did_change_since_previous_release(repo_dir: &str, path: &str) -> Result<bool> {
-    let Some(latest_release_branch) = get_latest_release_branch(repo_dir)? else {
-        return Ok(true); // No release found? Report as having changes.
-    };
-
-    let main_tip = get_latest_commit(repo_dir, "main")?;
-    let release_branch_tip = get_latest_commit(repo_dir, &latest_release_branch)?;
-    let common_ancestor = get_common_ancestor(repo_dir, &main_tip, &release_branch_tip)?;
-    did_change(repo_dir, path, &common_ancestor)
-}
-
 /// Returns whether a crate in the repo has changed since the previous release
 /// branch was created.
 ///

--- a/fiberplane-ci/src/utils/git.rs
+++ b/fiberplane-ci/src/utils/git.rs
@@ -168,19 +168,34 @@ pub fn get_latest_commit(repo_dir: &str, branch_name: &str) -> Result<String> {
 
 /// Returns the name of most recent release branch.
 pub fn get_latest_release_branch(repo_dir: &str) -> Result<Option<String>> {
-    let output = cmd!("git", "branch", "--list", "release-*")
-        .dir(repo_dir)
-        .stdout_capture()
-        .run()?
-        .stdout;
+    let output = cmd!(
+        "git",
+        "branch",
+        "--list",
+        "release-*",
+        "--format",
+        "%(refname)"
+    )
+    .dir(repo_dir)
+    .stdout_capture()
+    .run()?
+    .stdout;
     let release_branches = output
         .split(|byte| byte == &b'\n')
         .map(|slice| std::str::from_utf8(slice).map(str::trim))
         .collect::<Result<Vec<&str>, _>>()?;
     let latest_release_branch = release_branches
         .iter()
+        .filter(|ref_name| ref_name.starts_with("refs/heads/"))
+        .map(|ref_name| &ref_name[11..])
+        // Verify the branch matches the `release-YYYY-WW` scheme.
+        .filter(|branch| {
+            branch.len() == 15
+                && branch.chars().skip(8).take(4).all(|c| c.is_ascii_digit())
+                && branch.chars().nth(12).unwrap() == '-'
+                && branch.chars().skip(13).all(|c| c.is_ascii_digit())
+        })
         .reduce(|latest_release, release_branch| std::cmp::max(latest_release, release_branch))
-        .cloned()
         .map(str::to_owned);
     Ok(latest_release_branch)
 }


### PR DESCRIPTION
# Description

Filters release branches. This fixes two related issues:
- The filtering prevents an empty string from slipping past in case no release branches are found. This fixes the release for repositories that have had no release yet.
- It no longer matches branches that just happen to accidentally start with `release-`, such as the branch for this very PR.

Also cleans up some unused functions and updates the PR checklist now that we use a monorepo internally.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- ~~[ ] The changes have been tested to be backwards compatible.~~
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] New models module has been added to api generator xtask~~
- ~~[ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- ~~[ ] The CHANGELOG is updated.~~

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
* Monofiber: https://github.com/fiberplane/monofiber/pull/24

After merging, please merge related PRs ASAP, so others don't get blocked.
