### PR TITLE
Add `chartGridStrokeColor` prop allowing color overrides

### DIFF
--- a/fiberplane-charts/src/CoreChart/CoreChart.tsx
+++ b/fiberplane-charts/src/CoreChart/CoreChart.tsx
@@ -100,6 +100,7 @@ export function CoreChart({
                 gridRowsShown={props.gridRowsShown}
                 gridBordersShown={props.gridBordersShown}
                 gridDashArray={props.gridDashArray}
+                gridStrokeColor={props.gridStrokeColor}
               />
             )}
             <Group innerRef={graphContentRef} clipPath={`url(#${clipPathId})`}>

--- a/fiberplane-charts/src/CoreChart/GridWithAxes/GridWithAxes.tsx
+++ b/fiberplane-charts/src/CoreChart/GridWithAxes/GridWithAxes.tsx
@@ -18,6 +18,7 @@ type Props = {
   gridRowsShown?: boolean;
   gridBordersShown?: boolean;
   gridDashArray?: string;
+  gridStrokeColor?: string;
 };
 
 export const GridWithAxes = memo(function GridWithAxes({
@@ -30,10 +31,13 @@ export const GridWithAxes = memo(function GridWithAxes({
   gridRowsShown = true,
   gridBordersShown = true,
   gridDashArray,
+  gridStrokeColor,
 }: Props) {
   const [targetLower = 0, targetUpper = 0] = yScale.domain();
 
   const { colorBase300 } = useTheme();
+  const strokeColor = gridStrokeColor || colorBase300;
+
   const lower = useCustomSpring(targetLower);
   const upper = useCustomSpring(targetUpper);
 
@@ -69,7 +73,7 @@ export const GridWithAxes = memo(function GridWithAxes({
           scale={temporaryScale}
           width={xMax}
           height={yMax}
-          stroke={colorBase300}
+          stroke={strokeColor}
           strokeDasharray={gridDashArray}
         />
       )}
@@ -79,7 +83,7 @@ export const GridWithAxes = memo(function GridWithAxes({
           x2={xMax}
           y1={0}
           y2={yMax}
-          stroke={colorBase300}
+          stroke={strokeColor}
           strokeWidth={1}
           strokeDasharray={gridDashArray}
         />
@@ -89,7 +93,7 @@ export const GridWithAxes = memo(function GridWithAxes({
           scale={xScale}
           width={xMax}
           height={yMax}
-          stroke={colorBase300}
+          stroke={strokeColor}
           strokeDasharray={gridDashArray}
         />
       )}
@@ -103,7 +107,7 @@ export const GridWithAxes = memo(function GridWithAxes({
       <AxisLeft
         scale={temporaryScale}
         orientation={Orientation.left}
-        stroke={colorBase300}
+        stroke={strokeColor}
         strokeWidth={gridBordersShown ? 1 : 0}
         strokeDasharray={gridDashArray}
         hideTicks={true}

--- a/fiberplane-charts/src/CoreChart/types.ts
+++ b/fiberplane-charts/src/CoreChart/types.ts
@@ -116,6 +116,11 @@ export type CoreChartProps = {
   gridDashArray?: string;
 
   /**
+   * Override the color of the grid lines. (defaults to the theme's grid color)
+   */
+  gridStrokeColor?: string;
+
+  /**
    * Override the colors that the charts will use. If not specified several colors of the theme are used
    */
   colors?: Array<string>;


### PR DESCRIPTION
# Description

Add a `gridStrokeColor` prop to override the hardcoded color of the grids' stroke colors.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

~~-[ ] The changes have been tested to be backwards compatible.~~
~~- [ ] The OpenAPI schema and generated client have been updated.~~
~~- [ ] New models module has been added to api generator xtask~~
~~- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
~~- [ ] The CHANGELOG is updated.~~

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
