### PR TITLE
[WIP] Add tick formatter for three significant figures

### DIFF
--- a/fiberplane-charts/src/tickFormatters.test.ts
+++ b/fiberplane-charts/src/tickFormatters.test.ts
@@ -2,6 +2,7 @@ import {
   getScientificFormatterForAxis,
   getTimeFormatterForAxis,
   getPercentageFormatter,
+  getSignificantDigitsFormatter,
 } from "./tickFormatters";
 
 test("it can format large numbers with scientific notation", () => {
@@ -94,4 +95,20 @@ test("it can format percentages", () => {
   expect(percentageFormatter(0.1)).toBe("10%");
   expect(percentageFormatter(0.999)).toBe("99.9%");
   expect(percentageFormatter(1)).toBe("100%");
+});
+
+test("it can format 3 significant digits", () => {
+  const significantDigitsFormatter = getSignificantDigitsFormatter(3);
+
+  expect(significantDigitsFormatter(0)).toBe("0");
+  expect(significantDigitsFormatter(0.005)).toBe("0.005");
+  expect(significantDigitsFormatter(0.01)).toBe("0.01");
+  expect(significantDigitsFormatter(0.0101)).toBe("0.0101");
+  expect(significantDigitsFormatter(0.0106)).toBe("0.0106");
+  expect(significantDigitsFormatter(0.1)).toBe("0.1");
+  expect(significantDigitsFormatter(0.999)).toBe("0.999");
+  expect(significantDigitsFormatter(1)).toBe("1");
+  expect(significantDigitsFormatter(1.234)).toBe("1.23");
+  expect(significantDigitsFormatter(1.2345)).toBe("1.23");
+  expect(significantDigitsFormatter(12.345)).toBe("12.3");
 });

--- a/fiberplane-charts/src/tickFormatters.ts
+++ b/fiberplane-charts/src/tickFormatters.ts
@@ -221,6 +221,21 @@ function getScientificFormatterForUnits(
   };
 }
 
+export function getSignificantDigitsFormatter(
+  significantDigits: number,
+): TickFormatter {
+  return (value: number): string => {
+    if (value === 0) {
+      return "0";
+    }
+
+    const magnitude = Math.floor(Math.log10(Math.abs(value)));
+    const factor = 10 ** (significantDigits - 1 - magnitude);
+
+    return (Math.round(value * factor) / factor).toString();
+  };
+}
+
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 export function getTimeFormatterForAxis(axis: Axis): TickFormatter {

--- a/mondrian-charts/src/chart_to_svg/tick_formatters.rs
+++ b/mondrian-charts/src/chart_to_svg/tick_formatters.rs
@@ -46,6 +46,13 @@ pub enum FormatterKind {
     /// `100m`, `10`, `10k`.
     Scientific,
 
+    /// Formats a value using significant figures.
+    /// 
+    /// ## Examples (3 significant figures)
+    /// 
+    /// `12.3`, `0.123`, `0.00123`
+    SignificantFigures,
+
     /// Formats a time stamp expressed in seconds since the UNIX epoch.
     ///
     /// For brevity, the formatter omits the most significant parts of the time
@@ -70,6 +77,7 @@ pub fn get_formatter_for_axis(axis: &Axis, kind: FormatterKind) -> Box<dyn TickF
         FormatterKind::Exponent => Box::new(ExponentFormatter::new()),
         FormatterKind::Percentage => Box::new(PercentageFormatter::new()),
         FormatterKind::Scientific => Box::new(ScientificFormatter::for_axis(axis)),
+        FormatterKind::SignificantFigures => Box::new(SignificantFiguresFormatter::new(3)),
         FormatterKind::Time => Box::new(TimeFormatter::for_axis(axis)),
     }
 }
@@ -239,6 +247,37 @@ impl TickFormatter for ScientificFormatter {
         }
     }
 }
+
+pub struct SignificantFiguresFormatter {
+    significant_figures: i32,
+}
+
+impl SignificantFiguresFormatter {
+    pub fn new(significant_figures: i32) -> Self {
+        Self {
+            significant_figures,
+        }
+    }
+}
+
+impl TickFormatter for SignificantFiguresFormatter {
+    fn format(&self, value: f64) -> String {
+        if value == 0.0 {
+            "0".to_string();
+        }
+
+        let magnitude = (value.abs().log10()).floor() as i32;
+        let factor_exponent = self.significant_figures.checked_sub(1).and_then(|sf| sf.checked_sub(magnitude));
+        
+        // If there's an underflow or any other issue, default to 0 for the exponent
+        let factor = 10f64.powi(factor_exponent.unwrap_or(0));
+        
+        let result = (value * factor).round() / factor;
+
+        result.to_string()
+    }
+}
+
 
 pub struct TimeFormatter {
     scale: TimeScale,
@@ -668,6 +707,23 @@ mod tests {
         assert_eq!(formatter.format(0.), "0");
 
         assert_eq!(formatter.format(-1.23456789), "-1.2");
+    }
+
+    #[test]
+    fn test_significant_figures_formatter() {
+        let formatter = SignificantFiguresFormatter::new(3);
+
+        assert_eq!(formatter.format(0.0), "0");
+        assert_eq!(formatter.format(0.005), "0.005");
+        assert_eq!(formatter.format(0.01), "0.01");
+        assert_eq!(formatter.format(0.0101), "0.0101");
+        assert_eq!(formatter.format(0.0106), "0.0106");
+        assert_eq!(formatter.format(0.1), "0.1");
+        assert_eq!(formatter.format(0.999), "0.999");
+        assert_eq!(formatter.format(1.0), "1");
+        assert_eq!(formatter.format(1.234), "1.23");
+        assert_eq!(formatter.format(1.2345), "1.23");
+        assert_eq!(formatter.format(12.345), "12.3");
     }
 
     #[test]

--- a/mondrian-charts/src/chart_to_svg/tick_formatters.rs
+++ b/mondrian-charts/src/chart_to_svg/tick_formatters.rs
@@ -47,9 +47,9 @@ pub enum FormatterKind {
     Scientific,
 
     /// Formats a value using significant figures.
-    /// 
+    ///
     /// ## Examples (3 significant figures)
-    /// 
+    ///
     /// `12.3`, `0.123`, `0.00123`
     SignificantFigures,
 
@@ -267,17 +267,19 @@ impl TickFormatter for SignificantFiguresFormatter {
         }
 
         let magnitude = (value.abs().log10()).floor() as i32;
-        let factor_exponent = self.significant_figures.checked_sub(1).and_then(|sf| sf.checked_sub(magnitude));
-        
+        let factor_exponent = self
+            .significant_figures
+            .checked_sub(1)
+            .and_then(|sf| sf.checked_sub(magnitude));
+
         // If there's an underflow or any other issue, default to 0 for the exponent
         let factor = 10f64.powi(factor_exponent.unwrap_or(0));
-        
+
         let result = (value * factor).round() / factor;
 
         result.to_string()
     }
 }
-
 
 pub struct TimeFormatter {
     scale: TimeScale,


### PR DESCRIPTION
# Description

I'd like to expose a tick formatter for the request rate y axis that doesn't rely on scientific notation, as I find the labels like `355m` confusing when I look at them. (I haven't done an official survey, but there seems to be consensus on this throughout the frontend team.)

The test cases aren't exhaustive, and I think it actuality it might be nice to _fall back_ to scientific notation when the values are < .001

Anyways, I know it's WIP but I'm open to suggestions here.

Also, in the rust code, the publicly exposed formatter is _always_ three significant digits, whereas in the typescript code, we'd expose a general formatter factory that allows consumers to specify the number of significant digits they'd like.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [ ] The changes have been tested to be backwards compatible.
- [ ] The OpenAPI schema and generated client have been updated.
- [ ] New models module has been added to api generator xtask
- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [ ] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
