### PR TITLE
Rename xtask

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,4 @@
 git-fetch-with-cli = true
 
 [alias]
-xtask = "run --package xtask --"
+xtask = "run --package fiberplane-xtask --"

--- a/fiberplane-markdown/src/from_markdown/tests.rs
+++ b/fiberplane-markdown/src/from_markdown/tests.rs
@@ -196,7 +196,7 @@ fn parsing_ordered_lists(markdown: &str, cell_text: &[&str]) {
 #[test]
 fn parsing_adjacent_lists() {
     let markdown = "1. one\n2. two\n1. three\n- four\n- five";
-    let expected = vec![
+    let expected = [
         ("one", Some(1)),
         ("two", Some(2)),
         ("three", Some(3)),

--- a/fiberplane-models/Cargo.toml
+++ b/fiberplane-models/Cargo.toml
@@ -27,6 +27,7 @@ clap = { version = "4.1", default-features = false, optional = true, features = 
 form_urlencoded = "1"
 fp-bindgen = { workspace = true, optional = true, features = [
     "bytes-compat",
+    "serde-json-compat",
     "time-compat",
 ] }
 rmpv = "1"

--- a/fiberplane-openapi-rust-gen/src/generator.rs
+++ b/fiberplane-openapi-rust-gen/src/generator.rs
@@ -76,7 +76,7 @@ fn edit_cargo_toml(path: &Path, args: &GeneratorArgs) -> Result<()> {
 
     let mut manifest = open_manifest(&path)?;
 
-    let mut package_metadata = manifest
+    let package_metadata = manifest
         .package
         .as_mut()
         .context("`Cargo.toml` does not contain a [package] section")?;

--- a/fiberplane-openapi-rust-gen/src/routes.rs
+++ b/fiberplane-openapi-rust-gen/src/routes.rs
@@ -371,7 +371,7 @@ fn generate_function_body(
     writeln!(writer, "        Method::{method},")?;
 
     // https://stackoverflow.com/a/413077/11494565
-    let regex = Regex::new(r#"\{(.*?)\}"#).context("Failed to build regex")?;
+    let regex = Regex::new(r"\{(.*?)\}").context("Failed to build regex")?;
     let mut arguments = vec![];
 
     for captures in regex.captures_iter(endpoint) {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xtask"
+name = "fiberplane-xtask"
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }


### PR DESCRIPTION
# Description

This is a minor change that allows the `xtask` crate from this repo to co-exist with the crates from our other repos when combined using Git submodules.
