### PR TITLE
Bump prometheus query package

### DIFF
--- a/fiberplane-prometheus-query/package.json
+++ b/fiberplane-prometheus-query/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fiberplane/prometheus-query",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Package for querying Prometheus",
     "author": "Fiberplane <info@fiberplane.com>",
     "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
The currently published package `@fiberplane/prometheus-query` is empty (doesn't include a `dist/` folder). This bumps the prometheus-query version so a fix for an empty package can be published.