### PR TITLE
Sparkcharts should not get any axis/grid lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ changes if the major version hasn't changed.
 
 ## [Unreleased]
 
+- `fiberplane-charts': fix issue where SparkCharts would still get some grid lines.
 - `fiberplane-charts`: fix issue where height wasn't set/stored correctly for legend items (especially relevant for items that span multiple lines)
 - `fiberplane-charts`: updated with `chartTheme` prop allowing extending styles of the charts (#95)
 

--- a/fiberplane-charts/src/SparkChart/SparkChart.tsx
+++ b/fiberplane-charts/src/SparkChart/SparkChart.tsx
@@ -56,6 +56,7 @@ export function SparkChart({
         focusedShapeList={null}
         getShapeListColor={getShapeListColor}
         gridColumnsShown={false}
+        axisLinesShown={false}
         gridRowsShown={false}
         onChangeTimeRange={onChangeTimeRange}
         tickFormatters={tickFormatters}


### PR DESCRIPTION
# Description

axisLinesShown is an option that was added to the GridWithAxis component however the default value was set to true and so SparkCharts got lines. Which isn't the way they are used in the explorer. 

- [x] The changes have been tested to be backwards compatible.
- [x] The CHANGELOG is updated.
