### PR TITLE
Bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ crates do not strictly follow _SemVer_ although their versioning remains
 _compatible with_ SemVer, i.e. they will not contain breaking changes if the
 major version hasn't changed.
 
-## [Unreleased]
+## [v1.0.0-beta.7] - TBD
 
-- `fiberplane-charts': Fix issue where SparkCharts would still get some grid lines.
+- ...
 
-## [v1.0.0-beta.6] - 2023-10-18
+## [v1.0.0-beta.6] - 2023-10-20
 
+- `fiberplane-charts': Fix issue where SparkCharts would still get some grid
+  lines.
 - `fiberplane-charts`: Fix issue where height wasn't set/stored correctly for
   legend items (especially relevant for items that span multiple lines)
 - `fiberplane-charts`: Updated with `chartTheme` prop allowing extending styles

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,15 @@ base64uuid = { version = "1.0.0", path = "base64uuid", default-features = false 
 bytes = { version = "1", features = ["serde"] }
 fp-bindgen = { version = "3.0.0" }
 fp-bindgen-support = { version = "3.0.0" }
-fiberplane = { version = "1.0.0-beta.6", path = "fiberplane" }
-fiberplane-api-client = { version = "1.0.0-beta.6", path = "fiberplane-api-client" }
+fiberplane = { version = "1.0.0-beta.7", path = "fiberplane" }
+fiberplane-api-client = { version = "1.0.0-beta.7", path = "fiberplane-api-client" }
 fiberplane-ci = { version = "0.1.0", path = "fiberplane-ci" }
-fiberplane-markdown = { version = "1.0.0-beta.6", path = "fiberplane-markdown" }
-fiberplane-models = { version = "1.0.0-beta.6", path = "fiberplane-models" }
+fiberplane-markdown = { version = "1.0.0-beta.7", path = "fiberplane-markdown" }
+fiberplane-models = { version = "1.0.0-beta.7", path = "fiberplane-models" }
 fiberplane-openapi-rust-gen = { version = "0.1.0", path = "fiberplane-openapi-rust-gen" }
-fiberplane-provider-bindings = { version = "2.0.0-beta.6", path = "fiberplane-provider-protocol/fiberplane-provider-bindings" }
-fiberplane-provider-runtime = { version = "2.0.0-beta.6", path = "fiberplane-provider-protocol/fiberplane-provider-runtime" }
-fiberplane-templates = { version = "1.0.0-beta.6", path = "fiberplane-templates" }
+fiberplane-provider-bindings = { version = "2.0.0-beta.7", path = "fiberplane-provider-protocol/fiberplane-provider-bindings" }
+fiberplane-provider-runtime = { version = "2.0.0-beta.7", path = "fiberplane-provider-protocol/fiberplane-provider-runtime" }
+fiberplane-templates = { version = "1.0.0-beta.7", path = "fiberplane-templates" }
 insta = { version = "1.31.0" }
 once_cell = { version = "1.12" }
 serde = { version = "1", features = ["derive"] }

--- a/fiberplane-api-client/Cargo.toml
+++ b/fiberplane-api-client/Cargo.toml
@@ -34,7 +34,7 @@ description = "Generated API client for Fiberplane API"
 edition = "2021"
 name = "fiberplane-api-client"
 readme = "README.md"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 
 [package.license]
 workspace = true

--- a/fiberplane-markdown/Cargo.toml
+++ b/fiberplane-markdown/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 
 [dependencies]
 fiberplane-models = { workspace = true }

--- a/fiberplane-models/Cargo.toml
+++ b/fiberplane-models/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 
 [lib]
 crate-type = ["lib"]

--- a/fiberplane-provider-protocol/fiberplane-provider-bindings/Cargo.toml
+++ b/fiberplane-provider-protocol/fiberplane-provider-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiberplane-provider-bindings"
-version = "2.0.0-beta.6"
+version = "2.0.0-beta.7"
 authors = { workspace = true }
 edition = "2018"
 description = "Fiberplane Provider protocol bindings"

--- a/fiberplane-provider-protocol/fiberplane-provider-runtime/Cargo.toml
+++ b/fiberplane-provider-protocol/fiberplane-provider-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fiberplane-provider-runtime"
 description = "Wasmer runtime for Fiberplane Providers"
 readme = "README.md"
-version = "2.0.0-beta.6"
+version = "2.0.0-beta.7"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/fiberplane-templates/Cargo.toml
+++ b/fiberplane-templates/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 
 [features]
 default = ["convert", "expand", "examples"]

--- a/fiberplane/Cargo.toml
+++ b/fiberplane/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 
 [lib]
 crate-type = ["lib"]

--- a/mondrian-charts/Cargo.toml
+++ b/mondrian-charts/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 keywords = ["chart", "charts", "metrics", "prometheus", "opentelemetry"]
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "0.2.0"
+version = "0.3.0"
 
 [features]
 default = ["fiberplane", "image"]


### PR DESCRIPTION
This PR bumps the version numbers so they match the next release.
Please verify the version numbers are correct, and update the CHANGELOG manually. You
should merge this PR ASAP, but no later than before the next release cycle starts.

# Checklist

- [x] Version numbers are correct
- [x] `CHANGELOG.md` has been updated