### PR TITLE
Rename @fiberplane/fiberplane-charts

### DIFF
--- a/fiberplane-charts/package.json
+++ b/fiberplane-charts/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@fiberplane/fiberplane-charts",
+    "name": "@fiberplane/charts",
     "version": "0.2.0",
     "description": "Charts for visualizing metrics",
     "author": "Fiberplane <info@fiberplane.com>",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1543,9 +1543,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fiberplane/fiberplane-charts@workspace:fiberplane-charts":
+"@fiberplane/charts@workspace:fiberplane-charts":
   version: 0.0.0-use.local
-  resolution: "@fiberplane/fiberplane-charts@workspace:fiberplane-charts"
+  resolution: "@fiberplane/charts@workspace:fiberplane-charts"
   dependencies:
     "@svgr/rollup": ^7.0.0
     "@swc/core": ^1.3.51


### PR DESCRIPTION

# Description

This PR renames `@fiberplane/fiberplane-charts` to just `@fiberplane/charts`. This is a breaking change though the two main products that use it from us haven't really been switched over yet to the new setup so it's not a major breaking change in that sense.

The thing we may want to think about is what to do with the old @fiberplan/fiberplane-charts package on npm. It would be nice to publish something that says people should use the new `@fiberplane/charts` instead.
