### PR TITLE
Add `Input` to `@fiberplane/ui`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ major version hasn't changed.
 - `fiberplane-charts`: Export some util function and components related to 
   zooming/dragging to facilitate a more experimental graph (alert timeline)
 - `@fiberplane/ui`: Add initial setup component library & add `Button` component
+- `@fiberplane/ui`: Add `Input` components
 
 ## [v1.0.0-beta.6] - 2023-10-20
 

--- a/biome.json
+++ b/biome.json
@@ -1,29 +1,29 @@
 {
-    "$schema": "node_modules/@biomejs/biome/configuration_schema.json",
-    "formatter": {
-        "enabled": true,
-        "indentStyle": "space",
-        "indentSize": 2
-    },
-    "linter": {
-        "enabled": true,
-        "rules": {
-            "recommended": true,
-            "nursery": {
-                "useExhaustiveDependencies": "error",
-                "useHookAtTopLevel": "error"
-            }
-        }
-    },
-    "files": {
-        "ignore": [
-            ".vscode/**",
-            "dist/**",
-            "fiberplane-provider-protocol/ts-runtime/**",
-            "node_modules/**",
-            "target/**",
-            "**/providerTypes.ts",
-            "**/*.json"
-        ]
+  "$schema": "node_modules/@biomejs/biome/configuration_schema.json",
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentSize": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "nursery": {
+        "useExhaustiveDependencies": "error",
+        "useHookAtTopLevel": "error"
+      }
     }
+  },
+  "files": {
+    "ignore": [
+      ".vscode/**",
+      "dist/**",
+      "fiberplane-provider-protocol/ts-runtime/**",
+      "node_modules/**",
+      "target/**",
+      "**/providerTypes.ts",
+      "**/*.json"
+    ]
+  }
 }

--- a/fiberplane-ui/README.md
+++ b/fiberplane-ui/README.md
@@ -9,7 +9,7 @@ Contains UI elements for use in Fiberplane products.
 ```tsx
 import { Button } from "@fiberplane/ui";
 
-const MyComponent = () => {
+function MyComponent() {
   return (
     <Button
       onClick={() => { /* your onClick handler... */ }}

--- a/fiberplane-ui/package.json
+++ b/fiberplane-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiberplane/ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "UI components for Fiberplane",
   "author": "Fiberplane <info@fiberplane.com>",
   "license": "MIT OR Apache-2.0",

--- a/fiberplane-ui/src/components/Input/Checkbox.tsx
+++ b/fiberplane-ui/src/components/Input/Checkbox.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from "react";
 
 import {
-  StyledInput,
-  InputComponentContainer,
   HiddenInputElement,
   IconContainer,
+  InputComponentContainer,
+  StyledInput,
 } from "./common";
 
 type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement>;

--- a/fiberplane-ui/src/components/Input/Checkbox.tsx
+++ b/fiberplane-ui/src/components/Input/Checkbox.tsx
@@ -1,0 +1,40 @@
+import { forwardRef } from "react";
+
+import {
+  StyledInput,
+  InputComponentContainer,
+  HiddenInputElement,
+  IconContainer,
+} from "./common";
+
+type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const CheckBox = forwardRef<HTMLInputElement, CheckboxProps>(
+  function Checkbox({ checked, className, ...inputProps }, ref) {
+    return (
+      <InputComponentContainer className={className}>
+        <HiddenInputElement {...inputProps} ref={ref} checked={checked} />
+
+        <StyledInput>
+          {checked && (
+            <IconContainer>
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title>Selected</title>
+                <path
+                  d="M9.91741 12.6078L9.91867 12.6091L8.55777 14L4 9.34163L5.3609 7.95069L8.55651 11.2168L14.6391 5L16 6.39094L9.91741 12.6078Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </IconContainer>
+          )}
+        </StyledInput>
+      </InputComponentContainer>
+    );
+  },
+);

--- a/fiberplane-ui/src/components/Input/Input.tsx
+++ b/fiberplane-ui/src/components/Input/Input.tsx
@@ -1,0 +1,26 @@
+import { forwardRef } from "react";
+
+import { CheckBox } from "./Checkbox";
+import { RadioButton } from "./RadioButton";
+import { TextInput } from "./TextInput";
+import { LightSwitch } from "./LightSwitch";
+
+type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  props,
+  ref,
+) {
+  switch (props.type) {
+    case "checkbox":
+      return <CheckBox ref={ref} {...props} />;
+    case "radio":
+      return <RadioButton ref={ref} {...props} />;
+    case "text":
+      return <TextInput ref={ref} {...props} />;
+    case "lightswitch":
+      return <LightSwitch ref={ref} {...props} />;
+    default:
+      return <input ref={ref} {...props} />;
+  }
+});

--- a/fiberplane-ui/src/components/Input/Input.tsx
+++ b/fiberplane-ui/src/components/Input/Input.tsx
@@ -1,9 +1,9 @@
 import { forwardRef } from "react";
 
 import { CheckBox } from "./Checkbox";
+import { LightSwitch } from "./LightSwitch";
 import { RadioButton } from "./RadioButton";
 import { TextInput } from "./TextInput";
-import { LightSwitch } from "./LightSwitch";
 
 type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 

--- a/fiberplane-ui/src/components/Input/LightSwitch.tsx
+++ b/fiberplane-ui/src/components/Input/LightSwitch.tsx
@@ -1,0 +1,81 @@
+import { forwardRef } from "react";
+import styled, { css } from "styled-components";
+
+import {
+  HiddenInputElement,
+  InputComponentContainer,
+  StyledInput,
+} from "./common";
+
+type LightSwitchProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "type"
+>;
+
+export const LightSwitch = forwardRef<HTMLInputElement, LightSwitchProps>(
+  function LightSwitch({ checked, className, ...inputProps }, ref) {
+    return (
+      <LightSwitchComponentContainer className={className}>
+        <HiddenInputElement
+          {...inputProps}
+          ref={ref}
+          type="checkbox"
+          checked={checked}
+        />
+
+        <SwitchContainer>
+          <Switch />
+        </SwitchContainer>
+      </LightSwitchComponentContainer>
+    );
+  },
+);
+
+const LightSwitchComponentContainer = styled(InputComponentContainer)`
+  height: 20px;
+  width: 36px;
+`;
+
+const Switch = styled.div(
+  ({ theme }) => css`
+    position: absolute;
+    inset: 2px;
+    height: 80%;
+    aspect-ratio: 1;
+    border-radius: ${theme.radius.full};
+    background-color: ${theme.color.fg.onemphasis.default};
+    box-shadow: ${theme.effect.shadow.xxs};
+    transition: transform 0.2s ease-out;
+  `,
+);
+
+const SwitchContainer = styled(StyledInput)(
+  ({ theme }) => css`
+    border: unset;
+    background-color: unset;
+
+    position: relative;
+    border-radius: ${theme.radius.full};
+    background-color: ${theme.color.bg.disabled};
+
+    ${HiddenInputElement}:hover ~ & {
+      background-color: ${theme.color.bg.elevated.hover};
+    }
+
+    ${HiddenInputElement}:checked ~ & {
+      background-color: ${theme.color.bg.emphasis.primary};
+
+      ${Switch} {
+        transform: translateX(100%);
+      }
+    }
+
+    ${HiddenInputElement}:disabled ~ & {
+      background-color: ${theme.color.bg.disabled};
+
+      ${Switch} {
+        background-color: ${theme.color.fg.onemphasis.subtle};
+      }
+    }
+  `,
+);

--- a/fiberplane-ui/src/components/Input/RadioButton.tsx
+++ b/fiberplane-ui/src/components/Input/RadioButton.tsx
@@ -2,10 +2,10 @@ import { forwardRef } from "react";
 import styled, { css } from "styled-components";
 
 import {
-  StyledInput,
-  InputComponentContainer,
   HiddenInputElement,
   IconContainer,
+  InputComponentContainer,
+  StyledInput,
 } from "./common";
 
 type RadioButtonProps = React.InputHTMLAttributes<HTMLInputElement>;

--- a/fiberplane-ui/src/components/Input/RadioButton.tsx
+++ b/fiberplane-ui/src/components/Input/RadioButton.tsx
@@ -1,0 +1,38 @@
+import { forwardRef } from "react";
+import styled, { css } from "styled-components";
+
+import {
+  StyledInput,
+  InputComponentContainer,
+  HiddenInputElement,
+  IconContainer,
+} from "./common";
+
+type RadioButtonProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(
+  function RadioButton({ checked, className, ...inputProps }, ref) {
+    return (
+      <InputComponentContainer className={className}>
+        <HiddenInputElement {...inputProps} ref={ref} checked={checked} />
+
+        <RadioContainer>
+          {checked && (
+            <IconContainer>
+              <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                <title>Selected</title>
+                <circle fill="currentColor" cx="10" cy="10" r="5" />
+              </svg>
+            </IconContainer>
+          )}
+        </RadioContainer>
+      </InputComponentContainer>
+    );
+  },
+);
+
+const RadioContainer = styled(StyledInput)(
+  ({ theme }) => css`
+    border-radius: ${theme.radius.full};
+  `,
+);

--- a/fiberplane-ui/src/components/Input/TextInput.ts
+++ b/fiberplane-ui/src/components/Input/TextInput.ts
@@ -26,5 +26,5 @@ export const TextInput = styled.input(
     &:invalid {
       border-color: ${theme.color.fg.danger};
     }
-  `
+  `,
 );

--- a/fiberplane-ui/src/components/Input/TextInput.ts
+++ b/fiberplane-ui/src/components/Input/TextInput.ts
@@ -1,0 +1,30 @@
+import styled, { css } from "styled-components";
+
+export const TextInput = styled.input(
+  ({ theme }) => css`
+    background-color: ${theme.color.input.bg};
+    border: 1px solid ${theme.color.input.border};
+    border-radius: ${theme.radius.default};
+    color: ${theme.color.input.fg};
+    padding: 6px 12px;
+    outline: none;
+    font: ${theme.font.body.md.regular};
+    box-shadow: ${theme.effect.shadow.xxs};
+
+    transition: box-shadow 0.1s ease-in-out 0.05s, border-color 0.2s ease-in-out;
+
+    &::placeholder {
+      color: ${theme.color.input.fg.placeholder};
+    }
+
+    &:focus,
+    &:focus-visible {
+      box-shadow: ${theme.effect.focus.primary};
+      border-color: ${theme.color.border.primary};
+    }
+    &[data-invalid="true"],
+    &:invalid {
+      border-color: ${theme.color.fg.danger};
+    }
+  `
+);

--- a/fiberplane-ui/src/components/Input/common.ts
+++ b/fiberplane-ui/src/components/Input/common.ts
@@ -1,0 +1,78 @@
+import styled, { css } from "styled-components";
+
+export const InputComponentContainer = styled.div`
+  display: inline-block;
+  position: relative;
+  width: 16px;
+  height: 16px;
+  isolation: isolate;
+`;
+
+export const StyledInput = styled.div(
+  ({ theme }) => css`
+    display: grid;
+    place-items: center;
+    background-color: ${theme.color.bg.subtle};
+    border: 1px solid ${theme.color.fg.muted};
+    border-radius: ${theme.radius.minimal};
+    height: 100%;
+    width: 100%;
+    z-index: 1;
+    transition: box-shadow 0.1s ease-in-out 0.05s, border-color 0.2s ease-in-out,
+      background-color 0.2s ease-in-out;
+
+    ${HiddenInputElement}:hover ~ & {
+      border-color: ${theme.color.border.primary};
+    }
+
+    ${HiddenInputElement}:focus ~ & {
+      box-shadow: ${theme.effect.focus.primary};
+    }
+
+    ${HiddenInputElement}:checked ~ & {
+      border-color: ${theme.color.border.primary};
+      background-color: ${theme.color.bg.emphasis["primary-subtle"]};
+      color: ${theme.color.fg.primary};
+    }
+
+    ${HiddenInputElement}:disabled ~ & {
+      border-color: ${theme.color.border.default};
+      background-color: ${theme.color.bg.disabled};
+      color: ${theme.color.border.default};
+      cursor: default;
+    }
+  `,
+);
+
+export const IconContainer = styled.div`
+  @keyframes check {
+    to {
+      scale: 1;
+      opacity: 1;
+    }
+  }
+
+  & > svg {
+    position: absolute;
+    z-index: 2;
+    inset: 0;
+    height: 87.5%;
+    width: 87.5%;
+    margin: auto;
+    scale: 0.3;
+    opacity: 0;
+    animation: check 0.1s ease-in-out forwards;
+  }
+`;
+
+export const HiddenInputElement = styled.input`
+  appearance: none;
+  outline: none;
+  border: none;
+
+  cursor: pointer;
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  z-index: 3;
+`;

--- a/fiberplane-ui/src/components/Input/index.ts
+++ b/fiberplane-ui/src/components/Input/index.ts
@@ -1,0 +1,1 @@
+export * from "./Input";

--- a/fiberplane-ui/src/components/index.ts
+++ b/fiberplane-ui/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from "./Button";
+export * from "./Input";


### PR DESCRIPTION
# Description

Adds `Input` components to `@fiberplane/ui`.
Will bump version & release after review.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

~~- [ ] The changes have been tested to be backwards compatible.~~
~~- [ ] The OpenAPI schema and generated client have been updated.~~
~~- [ ] New models module has been added to api generator xtask~~
~~- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

~~After merging, please merge related PRs ASAP, so others don't get blocked.~~
