### PR TITLE
Add response utils to `prometheus-query`

### DIFF
--- a/fiberplane-prometheus-query/README.md
+++ b/fiberplane-prometheus-query/README.md
@@ -9,7 +9,8 @@ runtime would be overkill.
 In addition, it contains helpers for generating PromQL queries for Autometrics.
 Given a query type, a function name and optional other information, it will
 generate useful queries for generating common charts such as request rate, error
-rate and latency.
+rate and latency. Helpers for processing Prometheus responses to known queries
+are included as well.
 
 The query responses are converted to Provider types and are compatible with our
 [Provider Protocol](../fiberplane-provider-protocol/). This also ensures they're

--- a/fiberplane-prometheus-query/src/autometrics/index.ts
+++ b/fiberplane-prometheus-query/src/autometrics/index.ts
@@ -1,2 +1,3 @@
 export * from "./queries";
+export * from "./responses";
 export * from "./types";

--- a/fiberplane-prometheus-query/src/autometrics/queries.ts
+++ b/fiberplane-prometheus-query/src/autometrics/queries.ts
@@ -1,6 +1,11 @@
-import { TimeRange } from "..";
+import type { TimeRange } from "../providerTypes";
 import { getPrometheusWindowFromTimeRange } from "../utils";
-import { LatencyObjective, SuccessRateObjective } from "./types";
+import {
+  LatencyObjective,
+  Objective,
+  ScopedFunction,
+  SuccessRateObjective,
+} from "./types";
 
 /**
  * The list of metric types supported by Autometrics.
@@ -191,6 +196,27 @@ export function createFunctionRequestRateQuery({
 }
 
 /**
+ * Generates the PromQL query for an Autometrics-defined objective.
+ */
+export function createObjectiveQuery(
+  objective: Objective,
+  timeRange: TimeRange,
+  scopedFunction?: ScopedFunction,
+): string {
+  switch (objective.metric) {
+    case "latency":
+      return createSloQueryLatencyUnderThreshold(
+        objective,
+        timeRange,
+        scopedFunction,
+      );
+
+    case "success_rate":
+      return createSloQuerySuccessRate(objective, timeRange, scopedFunction);
+  }
+}
+
+/**
  * Generates the PromQL query to determine how many function call happened in a
  * given time window.
  */
@@ -307,7 +333,7 @@ export function createSloQueryLatencyUnderThresholdByFunction(
 }
 
 export function createSloQuerySuccessRate(
-  objective: { name: string },
+  objective: Objective,
   timeRange: TimeRange,
   function_?: { name: string; module: string },
 ) {

--- a/fiberplane-prometheus-query/src/autometrics/responses.ts
+++ b/fiberplane-prometheus-query/src/autometrics/responses.ts
@@ -1,0 +1,128 @@
+import { sortBy } from "../utils";
+import {
+  AmSeriesWithLatencyObjective,
+  AmSeriesWithSuccessObjective,
+  LatencyObjective,
+  Objective,
+  ScopedFunction,
+  SuccessRateObjective,
+} from "./types";
+
+export function filterUniqueFunctions(
+  functions: Array<ScopedFunction>,
+): Array<ScopedFunction> {
+  const uniqueFunctions: Array<ScopedFunction> = [];
+
+  for (const fn of functions) {
+    const isDuplicate = uniqueFunctions.some(
+      (other) =>
+        other.name === fn.name &&
+        other.module === fn.module &&
+        other.service_name === fn.service_name,
+    );
+
+    if (!isDuplicate) {
+      uniqueFunctions.push(fn);
+    }
+  }
+
+  return uniqueFunctions;
+}
+
+function getLatencyObjectiveKey({
+  objective_name,
+  objective_percentile,
+  objective_latency_threshold,
+}: AmSeriesWithLatencyObjective): string {
+  return `${objective_name}:latency:${objective_percentile}:${objective_latency_threshold}`;
+}
+
+export function getLatencyObjectiveFromSeries(
+  series: Array<AmSeriesWithLatencyObjective>,
+): Array<LatencyObjective> {
+  const objectivesByKey: Record<string, LatencyObjective> = {};
+
+  for (const currentSeries of series) {
+    const key = getLatencyObjectiveKey(currentSeries);
+
+    const objective = objectivesByKey[key];
+    if (objective) {
+      objective.series.push(currentSeries);
+    } else {
+      objectivesByKey[key] = {
+        series: [currentSeries],
+        name: currentSeries.objective_name,
+        functions: [],
+        metric: "latency",
+        target: {
+          percentile: currentSeries.objective_percentile,
+          threshold: currentSeries.objective_latency_threshold,
+        },
+      };
+    }
+  }
+
+  return transformObjectiveMetadata(objectivesByKey);
+}
+
+function getSuccessObjectiveKey({
+  objective_name,
+  objective_percentile,
+}: AmSeriesWithSuccessObjective): string {
+  return `${objective_name}:successRate:${objective_percentile}`;
+}
+
+export function getSuccessObjectiveFromSeries(
+  series: Array<AmSeriesWithSuccessObjective>,
+): Array<SuccessRateObjective> {
+  const objectivesByKey: Record<string, SuccessRateObjective> = {};
+
+  for (const currentSeries of series) {
+    const key = getSuccessObjectiveKey(currentSeries);
+
+    const objective = objectivesByKey[key];
+    if (objective) {
+      objective.series.push(currentSeries);
+    } else {
+      objectivesByKey[key] = {
+        series: [currentSeries],
+        name: currentSeries.objective_name,
+        functions: [],
+        metric: "success_rate",
+        target: {
+          percentile: currentSeries.objective_percentile,
+        },
+      };
+    }
+  }
+
+  return transformObjectiveMetadata(objectivesByKey);
+}
+
+/**
+ * Helper function for the final step of transforming objective metadata.
+ */
+function transformObjectiveMetadata<T extends Objective>(
+  objectivesByKey: Record<string, T>,
+): Array<T> {
+  const objectives = Object.values(objectivesByKey);
+
+  // NOTE - If you modify your objectives, old labels will also show up.
+  //        We need some form of conflict resolution :grimace:
+  for (const objective of objectives) {
+    // First, find all functions associated with this SLO.
+    // TODO - Should we check against the latest build? To make sure we're not
+    //        using old functions that are no longer part of the SLO?
+    objective.functions = filterUniqueFunctions(
+      objective.series.map((entry) => ({
+        name: entry.function,
+        module: entry.module,
+        service_name: entry.service_name,
+      })),
+    );
+    sortBy(objective.functions, (objective) => objective.name);
+    objective.functionsCount = objective.functions.length;
+  }
+
+  return objectives;
+}

--- a/fiberplane-prometheus-query/src/autometrics/types.ts
+++ b/fiberplane-prometheus-query/src/autometrics/types.ts
@@ -1,4 +1,7 @@
-type ScopedFunction = {
+/**
+ * Label set to refer to a function within a module and service.
+ */
+export type ScopedFunction = {
   name: string;
   module: string;
   service_name?: string;
@@ -20,7 +23,7 @@ type SuccessRateSeriesName =
 type AmSeries = {
   __name__: string;
   function: string;
-  module?: string;
+  module: string;
   service_name?: string;
 };
 
@@ -28,28 +31,22 @@ type AmSeries = {
  * An Autometrics function call histogram series with a latency objective
  * attached via labels.
  */
-export type AmSeriesWithLatencyObjective =
-  | AmSeries
-  | {
-      __name__: LatencySeriesName;
-      objective_name: string;
-      objective_latency_threshold: string;
-      objective_percentile: string;
-    };
+export type AmSeriesWithLatencyObjective = AmSeries & {
+  __name__: LatencySeriesName;
+  objective_name: string;
+  objective_latency_threshold: string;
+  objective_percentile: string;
+};
 
 /**
  * An Autometrics function call counter series with a success rate objective
  * attached via labels.
  */
-export type AmSeriesWithSuccessObjective =
-  | AmSeries
-  | {
-      __name__: SuccessRateSeriesName;
-      objective_name: string;
-      objective_percentile: string;
-    };
-
-// Schemas for transformed SLO data
+export type AmSeriesWithSuccessObjective = AmSeries & {
+  __name__: SuccessRateSeriesName;
+  objective_name: string;
+  objective_percentile: string;
+};
 
 export type SuccessRateTarget = {
   percentile: string;
@@ -63,7 +60,7 @@ export type SuccessRateObjective = {
   name: string;
   functions: Array<ScopedFunction>;
   functionsCount?: number;
-  metric: "successRate";
+  metric: "success_rate";
   target: SuccessRateTarget;
 };
 

--- a/fiberplane-prometheus-query/src/index.ts
+++ b/fiberplane-prometheus-query/src/index.ts
@@ -8,6 +8,6 @@ export type {
   Timestamp,
 } from "./providerTypes";
 
-export * as Autometrics from "./autometrics/queries";
+export * as Autometrics from "./autometrics";
 export * from "./timeseries";
 export { getPrometheusWindowFromTimeRange } from "./utils";

--- a/fiberplane-prometheus-query/src/utils/getPrometheusWindowFromTimeRange.ts
+++ b/fiberplane-prometheus-query/src/utils/getPrometheusWindowFromTimeRange.ts
@@ -1,4 +1,4 @@
-import { TimeRange } from "./providerTypes";
+import { TimeRange } from "../providerTypes";
 
 export function getPrometheusWindowFromTimeRange(timeRange: TimeRange) {
   const from = +new Date(timeRange.from) / 1000;

--- a/fiberplane-prometheus-query/src/utils/index.ts
+++ b/fiberplane-prometheus-query/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from "./getPrometheusWindowFromTimeRange";
+export * from "./sortBy";

--- a/fiberplane-prometheus-query/src/utils/sortBy.ts
+++ b/fiberplane-prometheus-query/src/utils/sortBy.ts
@@ -1,0 +1,23 @@
+/**
+ * Sorts an array ascending by priority.
+ *
+ * *Warning:* As this function uses `Array#sort()` it also mutates the input
+ * array.
+ */
+export function sortBy<T, U extends number | string>(
+  array: Array<T>,
+  getPriorityFn: (item: T) => U,
+  reverse = false,
+) {
+  return array.sort((a, b) => {
+    const priorityA = getPriorityFn(a);
+    const priorityB = getPriorityFn(b);
+    if (priorityA < priorityB) {
+      return reverse === true ? 1 : -1;
+    } else if (priorityA > priorityB) {
+      return reverse === true ? -1 : 1;
+    } else {
+      return 0;
+    }
+  });
+}


### PR DESCRIPTION
# Description

This adds helpers for parsing SLO responses to the `@fiberplane/prometheus-query` package. It seems there's less immediate opportunity to cut down on code duplication here, so I left it with just the SLO responses.

Implements AM-83.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] New models module has been added to api generator xtask~~
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- ~~[ ] The CHANGELOG is updated.~~

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
