### PR TITLE
Fix useragent detection

### DIFF
--- a/fiberplane-charts/src/utils/useragent.ts
+++ b/fiberplane-charts/src/utils/useragent.ts
@@ -1,6 +1,14 @@
-const os =
-  typeof navigator === "undefined"
-    ? ""
-    : navigator.platform.match(/mac|win|linux/i)?.[0]?.toLowerCase();
+let isMac = false;
 
-export const isMac = os === "mac";
+if (typeof navigator !== "undefined") {
+  const { platform } = navigator;
+  if (
+    platform?.startsWith("Mac") ||
+    platform?.startsWith("iPhone") ||
+    platform?.startsWith("iPad")
+  ) {
+    isMac = true;
+  }
+}
+
+export { isMac };


### PR DESCRIPTION
# Description

On my machine (Linux, Node v21.1), the unit tests started failing due to `navigator.platform` being `undefined`. This fixes it and changes the detection slightly to also include iPhone/iPad in the `isMac` definition. This should correct keyboard modifier suggestions in case somebody connects a keyboard to those devices :)

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] New models module has been added to api generator xtask~~
- ~~[ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- ~~[ ] The CHANGELOG is updated.~~

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
