### PR TITLE
Upgrade `styled-components` to v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ _compatible with_ SemVer, i.e. they will not contain breaking changes if the
 major version hasn't changed.
 
 ## [v1.0.0-beta.7] - TBD
-
 - `fiberplane-charts`: Export some util function and components related to 
   zooming/dragging to facilitate a more experimental graph (alert timeline)
 - `@fiberplane/ui`: Add initial setup component library & add `Button` component
 - `@fiberplane/ui`: Add `Input` components
 - `@fiberplane/ui`: Add `ThemeProvider`
 - `@fiberplane/ui`: Add `Icon` component
+- `@fiberplane/ui`: Upgrade `styled-components` to v6 & simplify `Button`
 
 ## [v1.0.0-beta.6] - 2023-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _compatible with_ SemVer, i.e. they will not contain breaking changes if the
 major version hasn't changed.
 
 ## [v1.0.0-beta.7] - TBD
+
 - `fiberplane-charts`: Export some util function and components related to 
   zooming/dragging to facilitate a more experimental graph (alert timeline)
 - `@fiberplane/ui`: Add initial setup component library & add `Button` component

--- a/fiberplane-charts/package.json
+++ b/fiberplane-charts/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "styled-components": "^5.3.0"
+    "styled-components": "^6.1.1"
   },
   "devDependencies": {
     "@svgr/rollup": "^6.5.0",
@@ -45,7 +45,6 @@
     "@types/jest": "^29.5.0",
     "@types/react": "^18.0.37",
     "@types/react-window": "^1.8.5",
-    "@types/styled-components": "^5.1.26",
     "@types/throttle-debounce": "^5.0.0",
     "jest": "^29.5.0",
     "react": "^18.2.0",
@@ -53,7 +52,7 @@
     "rollup": "^3.20.5",
     "rollup-plugin-dts": "^5.3.0",
     "rollup-plugin-swc3": "^0.10.3",
-    "styled-components": "^5.3.10",
+    "styled-components": "^6.1.1",
     "typescript": "^5.0.4"
   },
   "scripts": {

--- a/fiberplane-charts/src/BaseComponents/ButtonGroup.tsx
+++ b/fiberplane-charts/src/BaseComponents/ButtonGroup.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import styled, { css } from "styled-components";
+import { css, styled } from "styled-components";
 
 import { ChartThemeContext } from "../theme";
 

--- a/fiberplane-charts/src/BaseComponents/Containers.tsx
+++ b/fiberplane-charts/src/BaseComponents/Containers.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "styled-components";
 
 export const Box = styled.div`
   box-sizing: border-box;

--- a/fiberplane-charts/src/BaseComponents/Controls.tsx
+++ b/fiberplane-charts/src/BaseComponents/Controls.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import styled, { css } from "styled-components";
+import { css, styled } from "styled-components";
 
 import { ChartThemeContext } from "../theme";
 

--- a/fiberplane-charts/src/BaseComponents/IconButton.tsx
+++ b/fiberplane-charts/src/BaseComponents/IconButton.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useContext } from "react";
-import styled, { css } from "styled-components";
+import { css, styled } from "styled-components";
 
 import { ChartThemeContext } from "../theme";
 

--- a/fiberplane-charts/src/MetricsChart/MetricsChart.tsx
+++ b/fiberplane-charts/src/MetricsChart/MetricsChart.tsx
@@ -1,5 +1,5 @@
 import { memo, useContext, useMemo, useState } from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 
 import { ChartSizeContainerProvider } from "../CoreChart";
 import { CoreChart } from "../CoreChart";

--- a/fiberplane-charts/src/SparkChart/SparkChart.tsx
+++ b/fiberplane-charts/src/SparkChart/SparkChart.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import styled from "styled-components";
+import { styled } from "styled-components";
 
 import {
   ChartSizeContainerProvider,

--- a/fiberplane-charts/src/TimeseriesLegend/TimeseriesLegend.tsx
+++ b/fiberplane-charts/src/TimeseriesLegend/TimeseriesLegend.tsx
@@ -1,6 +1,6 @@
 import { useContext, useMemo, useRef } from "react";
 import { VariableSizeList } from "react-window";
-import styled, { css } from "styled-components";
+import { css, styled } from "styled-components";
 
 import { Container } from "../BaseComponents";
 import type { ShapeList } from "../Mondrian";

--- a/fiberplane-charts/src/TimeseriesLegend/TimeseriesLegendItem.tsx
+++ b/fiberplane-charts/src/TimeseriesLegend/TimeseriesLegendItem.tsx
@@ -1,5 +1,5 @@
 import { Fragment, memo, useContext, useLayoutEffect } from "react";
-import styled, { css } from "styled-components";
+import { css, styled } from "styled-components";
 
 import { Container, Icon } from "../BaseComponents";
 import { WithChartTheme } from "../chartThemeTypes";

--- a/fiberplane-charts/src/hooks/useExpandable.tsx
+++ b/fiberplane-charts/src/hooks/useExpandable.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useRef, useState } from "react";
-import styled, { css } from "styled-components";
+import { css, styled } from "styled-components";
 
 import { Icon } from "../BaseComponents";
 import { ChartThemeContext } from "../theme";

--- a/fiberplane-ui/package.json
+++ b/fiberplane-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiberplane/ui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "UI components for Fiberplane",
   "author": "Fiberplane <info@fiberplane.com>",
   "license": "MIT OR Apache-2.0",

--- a/fiberplane-ui/package.json
+++ b/fiberplane-ui/package.json
@@ -23,7 +23,6 @@
     "@swc/core": "^1.3.95",
     "@types/lodash.merge": "^4.6.9",
     "@types/react": "^18.0.37",
-    "@types/styled-components": "5.1.29",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-is": "^18.2.0",
@@ -32,7 +31,7 @@
     "rollup-plugin-dts": "^5.3.0",
     "rollup-plugin-import-css": "^3.3.5",
     "rollup-plugin-swc3": "^0.10.3",
-    "styled-components": "^5.3.11",
+    "styled-components": "^6.1.1",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2"
   },
@@ -40,7 +39,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.18.0",
-    "styled-components": "^5.3.0"
+    "styled-components": "^6.1.1"
   },
   "scripts": {
     "build": "rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",

--- a/fiberplane-ui/package.json
+++ b/fiberplane-ui/package.json
@@ -26,7 +26,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-is": "^18.2.0",
-    "react-router-dom": "^6.18.0",
     "rollup": "^3.20.5",
     "rollup-plugin-dts": "^5.3.0",
     "rollup-plugin-import-css": "^3.3.5",
@@ -38,7 +37,6 @@
   "peerDependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.18.0",
     "styled-components": "^6.1.1"
   },
   "scripts": {

--- a/fiberplane-ui/rollup.config.ts
+++ b/fiberplane-ui/rollup.config.ts
@@ -12,12 +12,7 @@ export default defineConfig([
       sourcemap: true,
       compact: true,
     },
-    external: [
-      "react-router-dom",
-      "react",
-      "react/jsx-runtime",
-      "styled-components",
-    ],
+    external: ["react", "react/jsx-runtime", "styled-components"],
     plugins: [
       svgr({
         svgoConfig: {

--- a/fiberplane-ui/src/components/Button.tsx
+++ b/fiberplane-ui/src/components/Button.tsx
@@ -3,7 +3,7 @@ import styled, { css } from "styled-components";
 
 type ButtonStyle = "primary" | "secondary" | "tertiary-color" | "tertiary-grey";
 
-type ButtonStyleProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+export type ButtonStyleProps = {
   buttonStyle?: ButtonStyle;
   buttonType?: "button" | "textButton";
 };
@@ -43,7 +43,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   },
 );
 
-type StyledButtonTransientProps = {
+export type StyledButtonTransientProps = {
   $buttonStyle: ButtonStyle;
 };
 

--- a/fiberplane-ui/src/components/Button.tsx
+++ b/fiberplane-ui/src/components/Button.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import styled, { css } from "styled-components";
+import { css, styled } from "styled-components";
 
 type ButtonStyle = "primary" | "secondary" | "tertiary-color" | "tertiary-grey";
 

--- a/fiberplane-ui/src/components/Button.tsx
+++ b/fiberplane-ui/src/components/Button.tsx
@@ -55,8 +55,10 @@ const StyledTextButton = styled.button<StyledButtonTransientProps>(
 );
 
 export const buttonStyling = css<StyledButtonTransientProps>(
-  ({ $buttonStyle, theme }) =>
-    css`
+  ({ $buttonStyle, theme }) => {
+    const buttonStyle = getButtonStyle($buttonStyle);
+
+    return css`
       /* reset default button styles */
       background: none;
       border: none;
@@ -79,7 +81,7 @@ export const buttonStyling = css<StyledButtonTransientProps>(
       transition: background-color 0.1s ease-in-out, color 0.1s ease-in-out,
         border-color 0.2s ease-in-out, box-shadow 0.1s ease-in-out 0.05s;
 
-      ${getButtonStyle($buttonStyle)}
+      ${buttonStyle}
 
       &:focus,
       &:hover,
@@ -95,7 +97,8 @@ export const buttonStyling = css<StyledButtonTransientProps>(
       &:focus-visible {
         box-shadow: ${theme.effect.focus.primary};
       }
-    `,
+    `;
+  },
 );
 
 export const textButtonStyling = css<StyledButtonTransientProps>(

--- a/fiberplane-ui/src/components/Button.tsx
+++ b/fiberplane-ui/src/components/Button.tsx
@@ -1,62 +1,27 @@
-import { forwardRef } from "react";
-import { Link, NavLink } from "react-router-dom";
-import styled, {
-  type DefaultTheme,
-  type StyledComponent,
-  css,
-} from "styled-components";
+import React, { forwardRef } from "react";
+import styled, { css } from "styled-components";
 
 type ButtonStyle = "primary" | "secondary" | "tertiary-color" | "tertiary-grey";
 
-type ButtonStyleProps = {
+type ButtonStyleProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   buttonStyle?: ButtonStyle;
+  buttonType?: "button" | "textButton";
 };
 
-type AsButton = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  asElement?: "button";
-};
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  ButtonStyleProps;
 
-type AsTextButton = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  asElement: "textButton";
-};
-
-type AsLink = React.ComponentProps<typeof StyledLink> & {
-  asElement: "link";
-};
-
-type AsNavLink = React.ComponentProps<typeof NavLink> & {
-  asElement: "navLink";
-};
-
-type AsAnchor = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
-  asElement: "externalLink";
-};
-
-type ButtonTypeProps = AsButton | AsTextButton | AsLink | AsNavLink | AsAnchor;
-
-type ButtonProps = ButtonTypeProps & ButtonStyleProps;
-
-type Button = React.ForwardRefExoticComponent<
-  React.PropsWithoutRef<ButtonProps> & React.RefAttributes<HTMLElement>
->;
-
-export const Button: Button = forwardRef<HTMLElement, ButtonProps>(
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   function Button(
     {
       children,
       buttonStyle = "primary",
-      asElement = "button",
+      buttonType = "button",
       ...elementProps
     },
     ref,
   ) {
-    switch (asElement) {
-      case "button":
-        return (
-          <StyledButton ref={ref} $buttonStyle={buttonStyle} {...elementProps}>
-            {children}
-          </StyledButton>
-        );
+    switch (buttonType) {
       case "textButton":
         return (
           <StyledTextButton
@@ -67,26 +32,10 @@ export const Button: Button = forwardRef<HTMLElement, ButtonProps>(
             {children}
           </StyledTextButton>
         );
-      case "link":
+
+      default:
         return (
-          <StyledLink ref={ref} $buttonStyle={buttonStyle} {...elementProps}>
-            {children}
-          </StyledLink>
-        );
-      case "navLink":
-        return (
-          <StyledNavLink ref={ref} $buttonStyle={buttonStyle} {...elementProps}>
-            {children}
-          </StyledNavLink>
-        );
-      case "externalLink":
-        return (
-          <StyledButton
-            ref={ref}
-            as="a"
-            $buttonStyle={buttonStyle}
-            {...elementProps}
-          >
+          <StyledButton ref={ref} $buttonStyle={buttonStyle} {...elementProps}>
             {children}
           </StyledButton>
         );
@@ -94,11 +43,18 @@ export const Button: Button = forwardRef<HTMLElement, ButtonProps>(
   },
 );
 
-type ButtonSCProps = {
+type StyledButtonTransientProps = {
   $buttonStyle: ButtonStyle;
 };
 
-export const buttonStyling = css<ButtonSCProps>(
+const StyledButton = styled.button<StyledButtonTransientProps>(
+  () => buttonStyling,
+);
+const StyledTextButton = styled.button<StyledButtonTransientProps>(
+  () => textButtonStyling,
+);
+
+export const buttonStyling = css<StyledButtonTransientProps>(
   ({ $buttonStyle, theme }) =>
     css`
       /* reset default button styles */
@@ -142,27 +98,9 @@ export const buttonStyling = css<ButtonSCProps>(
     `,
 );
 
-const StyledButton = styled.button<ButtonSCProps>`
-  ${buttonStyling}
-`;
-
-type StyledLink = StyledComponent<
-  typeof Link,
-  DefaultTheme,
-  ButtonSCProps,
-  never
->;
-const StyledLink: StyledLink = styled(Link)<ButtonSCProps>`
-  ${buttonStyling}
-`;
-
-const StyledNavLink = styled(NavLink)<ButtonSCProps>`
-  ${buttonStyling}
-`;
-
-const StyledTextButton = styled.button<ButtonSCProps>(
+export const textButtonStyling = css<StyledButtonTransientProps>(
   ({ $buttonStyle, theme }) =>
-    css`
+    css<StyledButtonTransientProps>`
       ${buttonStyling}
 
       padding: 4px;

--- a/fiberplane-ui/src/components/Input/LightSwitch.tsx
+++ b/fiberplane-ui/src/components/Input/LightSwitch.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import styled, { css } from "styled-components";
+import { css, styled } from "styled-components";
 
 import {
   HiddenInputElement,

--- a/fiberplane-ui/src/components/Input/RadioButton.tsx
+++ b/fiberplane-ui/src/components/Input/RadioButton.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import styled, { css } from "styled-components";
+import { css, styled } from "styled-components";
 
 import {
   HiddenInputElement,

--- a/fiberplane-ui/src/components/Input/TextInput.ts
+++ b/fiberplane-ui/src/components/Input/TextInput.ts
@@ -1,4 +1,4 @@
-import styled, { css } from "styled-components";
+import { css, styled } from "styled-components";
 
 export const TextInput = styled.input(
   ({ theme }) => css`

--- a/fiberplane-ui/src/components/Input/common.ts
+++ b/fiberplane-ui/src/components/Input/common.ts
@@ -1,4 +1,4 @@
-import styled, { css } from "styled-components";
+import { css, styled } from "styled-components";
 
 export const InputComponentContainer = styled.div`
   display: inline-block;

--- a/fiberplane-ui/src/theme/README.md
+++ b/fiberplane-ui/src/theme/README.md
@@ -12,7 +12,8 @@ theme object in the theme provider.
 
 ## Updating the theme with updated Figma values
 
-1. Open Figma and open all files on the left sidebar;
+1. (when only having read access) Open Figma and open all files on the left
+  sidebar;
 2. Build the plugin locally & run in Figma (follow instructions in the
   [plugin repo](https://github.com/oscarvz/figma-plugin));
 3. Copy the generated CSS into `src/theme/figma/variables.ts` and the TS object
@@ -23,8 +24,8 @@ All set!
 
 > [!important]
 > Figma has a limitation where it only returns the variables in your current
-> workspace. To make sure all defined variables are returned, make sure to
-> follow step 1.
+> workspace when you only have read access to the project. To make sure all
+> defined variables are returned, make sure to follow step 1.
 
 > [!important]
 > When updating the theme it's important you **always** update both the CSS and

--- a/fiberplane-ui/src/theme/ThemeProvider.tsx
+++ b/fiberplane-ui/src/theme/ThemeProvider.tsx
@@ -1,4 +1,7 @@
-import { ThemeProvider as StyledComponentsThemeProvider } from "styled-components";
+import {
+  StyleSheetManager,
+  ThemeProvider as StyledComponentsThemeProvider,
+} from "styled-components";
 
 import { extendedTheme } from "./extendedTheme/extendedTheme";
 import { GlobalStyle } from "./globalStyle";
@@ -14,9 +17,11 @@ type ThemeProviderProps = {
  */
 export function ThemeProvider({ children }: ThemeProviderProps) {
   return (
-    <StyledComponentsThemeProvider theme={extendedTheme}>
-      <GlobalStyle />
-      {children}
-    </StyledComponentsThemeProvider>
+    <StyleSheetManager enableVendorPrefixes>
+      <StyledComponentsThemeProvider theme={extendedTheme}>
+        <GlobalStyle />
+        {children}
+      </StyledComponentsThemeProvider>
+    </StyleSheetManager>
   );
 }


### PR DESCRIPTION
# Description

Upgrade `styled-components` from v5 to v6.

Also simplifies `Button.tsx` which gets rid of `react-router-dom` as a dependency.

# Checklist

<!--
AM-143
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
~~- [ ] The OpenAPI schema and generated client have been updated.~~
~~- [ ] New models module has been added to api generator xtask~~
~~- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

<!-- After merging, please merge related PRs ASAP, so others don't get blocked. -->
