### PR TITLE
Add configurable stroke width to mondrian-charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ major version hasn't changed.
 - `@fiberplane/ui`: Add `Icon` component
 - `@fiberplane/ui`: Upgrade `styled-components` to v6 & simplify `Button`
 - `@fiberplane/ui`: Add webhooks icon & expose icon type guard
+- `fiberplane-charts`: Allow configuring stroke width of chart content lines
+- `mondrian-charts`: Allow configuring stroke width of chart content lines
 
 ## mondrian-charts [v0.4.0] - 2023-11-30
 

--- a/fiberplane-charts/src/CoreChart/ChartContent.tsx
+++ b/fiberplane-charts/src/CoreChart/ChartContent.tsx
@@ -7,6 +7,7 @@ type Props<S, P> = {
   chart: AbstractChart<S, P>;
   focusedShapeList: ShapeList<S, P> | null;
   getShapeListColor: (source: S, index: number) => string;
+  strokeWidth: number;
   scales: Scales;
 };
 
@@ -15,6 +16,7 @@ export function ChartContent<S, P>({
   chart,
   focusedShapeList,
   getShapeListColor,
+  strokeWidth,
   scales,
 }: Props<S, P>): JSX.Element {
   return (
@@ -27,6 +29,7 @@ export function ChartContent<S, P>({
             color={getShapeListColor(shapeList.source, listIndex)}
             focused={shapeList === focusedShapeList}
             key={`${listIndex}-${shapeIndex}`}
+            strokeWidth={strokeWidth}
             scales={scales}
             shape={shape}
           />

--- a/fiberplane-charts/src/CoreChart/ChartShape/AreaShape.tsx
+++ b/fiberplane-charts/src/CoreChart/ChartShape/AreaShape.tsx
@@ -15,6 +15,7 @@ export const AreaShape = memo(function AreaShape<P>({
   color,
   focused,
   scales,
+  strokeWidth,
 }: Props<P>): JSX.Element {
   const id = useId();
   const gradientId = `line-${id}`;
@@ -23,6 +24,8 @@ export const AreaShape = memo(function AreaShape<P>({
   const x = (point: { x: number }) => scales.xScale(point.x);
   const y0 = (point: { yMin: number }) => scales.yScale(point.yMin);
   const y1 = (point: { yMax: number }) => scales.yScale(point.yMax);
+
+  const focusedStrokeWidth = strokeWidth * 1.5;
 
   return (
     <g opacity={focused || !anyFocused ? 1 : 0.2}>
@@ -38,7 +41,7 @@ export const AreaShape = memo(function AreaShape<P>({
         d={createAreaPathDef(area.points, { x, y0, y1 })}
         stroke={color}
         strokeDasharray={area.strokeDasharray?.join(" ")}
-        strokeWidth={focused ? 1.5 : 1}
+        strokeWidth={focused ? focusedStrokeWidth : strokeWidth}
         fill={areaGradientShown ? gradientRef : "none"}
       />
     </g>

--- a/fiberplane-charts/src/CoreChart/ChartShape/LineShape.tsx
+++ b/fiberplane-charts/src/CoreChart/ChartShape/LineShape.tsx
@@ -15,12 +15,15 @@ export const LineShape = memo(function LineShape<P>({
   focused,
   line,
   scales,
+  strokeWidth,
 }: Props<P>): JSX.Element {
   const id = useId();
   const gradientId = `line-${id}`;
 
   const x = (point: { x: number }) => scales.xScale(point.x);
   const y = (point: { y: number }) => scales.yScale(point.y);
+
+  const focusedStrokeWidth = strokeWidth * 1.5;
 
   return (
     <g opacity={focused || !anyFocused ? 1 : 0.2}>
@@ -43,7 +46,7 @@ export const LineShape = memo(function LineShape<P>({
         d={createLinePathDef(line.points, { x, y })}
         stroke={color}
         strokeDasharray={line.strokeDasharray?.join(" ")}
-        strokeWidth={focused ? 1.5 : 1}
+        strokeWidth={focused ? focusedStrokeWidth : strokeWidth}
         fill="none"
       />
     </g>

--- a/fiberplane-charts/src/CoreChart/ChartShape/types.ts
+++ b/fiberplane-charts/src/CoreChart/ChartShape/types.ts
@@ -29,4 +29,9 @@ export type CommonShapeProps = {
    * Chart scales for converting abstract coordinates to pixel values.
    */
   scales: Scales;
+
+  /**
+   * The stroke width of the chart line.
+   */
+  strokeWidth: number;
 };

--- a/fiberplane-charts/src/CoreChart/CoreChart.tsx
+++ b/fiberplane-charts/src/CoreChart/CoreChart.tsx
@@ -20,6 +20,7 @@ export function CoreChart<S, P>({
   getShapeListColor,
   onChangeTimeRange,
   readOnly = false,
+  shapeStrokeWidth = 1,
   showTooltip,
   timeRange,
   ...props
@@ -119,6 +120,7 @@ export function CoreChart<S, P>({
             areaGradientShown={areaGradientShown}
             chart={chart}
             getShapeListColor={getShapeListColor}
+            strokeWidth={shapeStrokeWidth}
             scales={scales}
           />
         </g>

--- a/fiberplane-charts/src/CoreChart/types.ts
+++ b/fiberplane-charts/src/CoreChart/types.ts
@@ -77,6 +77,11 @@ export type CoreChartProps<S, P> = {
   readOnly?: boolean;
 
   /**
+   * Override stroke width of the lines inside the chart. (default: 1)
+   */
+  shapeStrokeWidth?: number;
+
+  /**
    * Whether the Y scale should be animated across changes.
    */
   shouldAnimateYScale?: boolean;

--- a/mondrian-charts/src/chart_to_svg/constants.rs
+++ b/mondrian-charts/src/chart_to_svg/constants.rs
@@ -12,6 +12,9 @@ pub(super) const POINT_RADIUS_FOCUSED: u16 = 4;
 // This overflow margin ensures that the point is still visible.
 pub(super) const CHART_SHAPE_OVERFLOW_MARGIN: u16 = POINT_RADIUS_FOCUSED;
 
+// Stroke width of chart content lines
+pub(super) const SHAPE_STROKE_WIDTH: f32 = 1.0;
+
 pub(super) const TICK_FONT_FAMILY: &str = "sans-serif";
 pub(super) const TICK_FONT_SIZE: u16 = 20;
 pub(super) const TICK_FONT_WEIGHT: u16 = 400;

--- a/mondrian-charts/src/chart_to_svg/generate_chart_content_svg.rs
+++ b/mondrian-charts/src/chart_to_svg/generate_chart_content_svg.rs
@@ -1,6 +1,6 @@
 use super::create_area_path_def::create_area_path_def;
 use super::create_line_path_def::create_line_path_def;
-use super::{ChartOptions, Scales, POINT_RADIUS};
+use super::{ChartOptions, Scales, POINT_RADIUS, SHAPE_STROKE_WIDTH};
 use crate::types::{Area, Line, MondrianChart, Point, Rectangle, Shape};
 use itertools::join;
 use std::borrow::Cow;
@@ -34,6 +34,7 @@ pub(super) fn generate_chart_content_svg<'a, S, P>(
 struct ShapeOptions<'a> {
     area_gradient_shown: bool,
     color: &'a str,
+    stroke_width: f32,
     index: usize,
 }
 
@@ -45,6 +46,7 @@ impl<'a> ShapeOptions<'a> {
     ) -> Self {
         let ChartOptions {
             area_gradient_shown,
+            shape_stroke_width,
             get_shape_list_color,
             ..
         } = options;
@@ -52,6 +54,7 @@ impl<'a> ShapeOptions<'a> {
         Self {
             area_gradient_shown: *area_gradient_shown,
             color: get_shape_list_color(source, index),
+            stroke_width: shape_stroke_width.unwrap_or(SHAPE_STROKE_WIDTH),
             index,
         }
     }
@@ -70,6 +73,7 @@ fn generate_area_svg<P>(area: &Area<P>, scales: &Scales, options: ShapeOptions) 
     let ShapeOptions {
         area_gradient_shown,
         color,
+        stroke_width,
         index,
     } = options;
 
@@ -95,13 +99,16 @@ fn generate_area_svg<P>(area: &Area<P>, scales: &Scales, options: ShapeOptions) 
         |point| scales.y(point.y_max),
     );
 
-    format!(r#"{defs}<path d="{path_def}" stroke="{color}" stroke-width="1" fill="{fill}" />"#)
+    format!(
+        r#"{defs}<path d="{path_def}" stroke="{color}" stroke-width="{stroke_width}" fill="{fill}" />"#
+    )
 }
 
 fn generate_line_svg<P>(line: &Line<P>, scales: &Scales, options: ShapeOptions) -> String {
     let ShapeOptions {
         area_gradient_shown,
         color,
+        stroke_width,
         index,
     } = options;
 
@@ -132,7 +139,9 @@ fn generate_line_svg<P>(line: &Line<P>, scales: &Scales, options: ShapeOptions) 
         |point| scales.y(point.y),
     );
 
-    format!(r#"{gradient}<path d="{path_def}" stroke="{color}" stroke-width="1" fill="none" />"#)
+    format!(
+        r#"{gradient}<path d="{path_def}" stroke="{color}" stroke-width="{stroke_width}" fill="none" />"#
+    )
 }
 
 fn generate_point_svg<P>(point: &Point<P>, scales: &Scales, options: ShapeOptions) -> String {

--- a/mondrian-charts/src/chart_to_svg/mod.rs
+++ b/mondrian-charts/src/chart_to_svg/mod.rs
@@ -43,6 +43,9 @@ pub struct ChartOptions<'a, S> {
     /// Optional dasharray to apply to the grid lines.
     pub grid_stroke_dasharray: &'a [f32],
 
+    /// Optional stroke width of the chart content lines.
+    pub shape_stroke_width: Option<f32>,
+
     /// Callback to determine the color that should be used for a given shape
     /// list.
     ///

--- a/mondrian-charts/src/fiberplane/tests/test_generate_bar_chart_from_timeseries.rs
+++ b/mondrian-charts/src/fiberplane/tests/test_generate_bar_chart_from_timeseries.rs
@@ -47,6 +47,7 @@ fn test_generate_bar_chart_from_timeseries() {
             grid_rows_shown: true,
             grid_stroke_color: "#e7e7e7",
             grid_stroke_dasharray: Default::default(),
+            shape_stroke_width: None,
             get_shape_list_color: &|_, _| "#c00eae",
             tick_color: "#a4a4a4",
             x_formatter: Some(FormatterKind::Time),

--- a/mondrian-charts/src/fiberplane/tests/test_generate_combined_chart.rs
+++ b/mondrian-charts/src/fiberplane/tests/test_generate_combined_chart.rs
@@ -56,6 +56,7 @@ fn test_generate_line_chart_from_timeseries() {
             grid_rows_shown: false,
             grid_stroke_color: "#e7e7e7",
             grid_stroke_dasharray: Default::default(),
+            shape_stroke_width: None,
             get_shape_list_color: &|source, _| match source {
                 SeriesSource::Timeseries(_) => "#c00eae",
                 SeriesSource::Events => "#4c7aff",

--- a/mondrian-charts/src/fiberplane/tests/test_generate_line_chart_from_timeseries.rs
+++ b/mondrian-charts/src/fiberplane/tests/test_generate_line_chart_from_timeseries.rs
@@ -47,6 +47,7 @@ fn test_generate_line_chart_from_timeseries() {
             grid_rows_shown: true,
             grid_stroke_color: "#e7e7e7",
             grid_stroke_dasharray: Default::default(),
+            shape_stroke_width: None,
             get_shape_list_color: &|_, _| "#c00eae",
             tick_color: "#a4a4a4",
             x_formatter: Some(FormatterKind::Time),

--- a/mondrian-charts/src/fiberplane/tests/test_generate_stacked_bar_chart_from_timeseries.rs
+++ b/mondrian-charts/src/fiberplane/tests/test_generate_stacked_bar_chart_from_timeseries.rs
@@ -67,6 +67,7 @@ fn test_generate_stacked_bar_chart_from_timeseries() {
             grid_rows_shown: false,
             grid_stroke_color: "#e7e7e7",
             grid_stroke_dasharray: Default::default(),
+            shape_stroke_width: None,
             get_shape_list_color: &|_, index| if index % 2 == 0 { "#c00eae" } else { "#23304a" },
             tick_color: "#a4a4a4",
             x_formatter: Some(FormatterKind::Time),

--- a/mondrian-charts/src/fiberplane/tests/test_generate_stacked_line_chart_from_timeseries.rs
+++ b/mondrian-charts/src/fiberplane/tests/test_generate_stacked_line_chart_from_timeseries.rs
@@ -67,6 +67,7 @@ fn test_generate_stacked_line_chart_from_timeseries() {
             grid_rows_shown: true,
             grid_stroke_color: "#e7e7e7",
             grid_stroke_dasharray: Default::default(),
+            shape_stroke_width: None,
             get_shape_list_color: &|_, index| if index % 2 == 0 { "#c00eae" } else { "#23304a" },
             tick_color: "#a4a4a4",
             x_formatter: Some(FormatterKind::Time),


### PR DESCRIPTION
# Description

This pr adds `shape_stroke_width` optional field to `ChartOptions` with a default of 1 (current value). This change will be used by our new alert slack bot that you should definitely check out 👀

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
~~- [ ] The OpenAPI schema and generated client have been updated.~~
~~- [ ] New models module has been added to api generator xtask~~
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
* Monofiber: https://github.com/fiberplane/monofiber/pull/163

After merging, please merge related PRs ASAP, so others don't get blocked.
