### PR TITLE
`@fiberplane/ui`: `IconButton` fixes

### DIFF
--- a/fiberplane-ui/src/components/IconButton.tsx
+++ b/fiberplane-ui/src/components/IconButton.tsx
@@ -3,13 +3,16 @@ import { styled } from "styled-components";
 import { Button } from "./Button";
 import { Icon } from "./Icon";
 
-type IconButtonProps = Omit<React.ComponentProps<typeof Button>, "children"> &
+type IconButtonProps = Omit<
+  React.ComponentProps<typeof Button>,
+  "buttonType" | "children"
+> &
   Pick<React.ComponentProps<typeof Icon>, "iconType">;
 
 export function IconButton({ iconType, ...buttonProps }: IconButtonProps) {
   return (
     <StyledButton {...buttonProps}>
-      <Icon iconType={iconType} />
+      <Icon height="59%" width="59%" iconType={iconType} />
     </StyledButton>
   );
 }


### PR DESCRIPTION
# Description

- Sets icon size relative to parent button size
- Omit redundant `buttonType` prop

Fixes FP-(issue)

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

~~- [ ] The changes have been tested to be backwards compatible.~~
~~- [ ] The OpenAPI schema and generated client have been updated.~~
~~- [ ] New models module has been added to api generator xtask~~
~~- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [ ] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

<!-- After merging, please merge related PRs ASAP, so others don't get blocked. -->
