### PR TITLE
Rename Yarn worktree

### DIFF
--- a/fiberplane-ui/rollup.config.ts
+++ b/fiberplane-ui/rollup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig([
     external: ["react", "react/jsx-runtime", "styled-components"],
     plugins: [
       svgr({
+        jsxRuntime: "automatic",
         svgoConfig: {
           plugins: [
             {

--- a/fiberplane-ui/src/components/Button.tsx
+++ b/fiberplane-ui/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 import { css, styled } from "styled-components";
 
 type ButtonStyle = "primary" | "secondary" | "tertiary-color" | "tertiary-grey";

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fiberplane",
+  "name": "fiberplane-yarn-worktree",
   "description": "Fiberplane Yarn worktree",
   "repository": "https://github.com/fiberplane/fiberplane",
   "author": "Fiberplane <info@fiberplane.com>",


### PR DESCRIPTION
# Description

Since we're using Nx in `monofiber`, and I'm about to enable the Rust plugin there, I ran into a conflict because the Yarn worktree is named `fiberplane`, which is also the name of a Rust crate inside this repository. So I'm renaming the worktree name (which AFAIK we don't use for anything anyway) to resolve the conflict.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- ~~[ ] The changes have been tested to be backwards compatible.~~
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] New models module has been added to api generator xtask~~
- ~~[ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- ~~[ ] The CHANGELOG is updated.~~

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
