### PR TITLE
add integrations listing for user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ major version hasn't changed.
   creating notebooks.
 - `fiberplane-api-client`: Add queries to work with front matter schemas associated with
   a workspace.
+- `fiberplane-models`: Added various structs related to Integrations (#142)
+- `fiberplane-api-client`: Added `integrations_list` endpoint (#142)
 
 ## mondrian-charts [v0.4.0] - 2023-11-30
 

--- a/fiberplane-api-client/Cargo.toml
+++ b/fiberplane-api-client/Cargo.toml
@@ -30,14 +30,18 @@ path = "src/lib.rs"
 required-features = []
 
 [package]
+authors = ["Fiberplane <info@fiberplane.com>"]
 description = "Generated API client for Fiberplane API"
 edition = "2021"
 name = "fiberplane-api-client"
 readme = "README.md"
-version = "1.0.0-beta.7"
+rust-version = "1.64"
 
 [package.license]
 workspace = true
 
 [package.repository]
+workspace = true
+
+[package.version]
 workspace = true

--- a/fiberplane-api-client/src/lib.rs
+++ b/fiberplane-api-client/src/lib.rs
@@ -16,6 +16,7 @@ pub(crate) mod models {
     pub(crate) use fiberplane_models::events::*;
     pub(crate) use fiberplane_models::files::*;
     pub(crate) use fiberplane_models::formatting::*;
+    pub(crate) use fiberplane_models::integrations::*;
     pub(crate) use fiberplane_models::labels::*;
     pub(crate) use fiberplane_models::names::*;
     pub(crate) use fiberplane_models::notebooks::operations::*;
@@ -557,6 +558,14 @@ pub async fn profile_get(client: &ApiClient) -> Result<models::Profile> {
 #[doc = r#"List of all available providers and if they're linked to the current user"#]
 pub async fn oid_connections_list(client: &ApiClient) -> Result<Vec<models::OidConnection>> {
     let mut builder = client.request(Method::GET, "/api/profile/connections")?;
+    let response = builder.send().await?.error_for_status()?.json().await?;
+
+    Ok(response)
+}
+
+#[doc = r#"Get a list of all integrations and their status"#]
+pub async fn integrations_get(client: &ApiClient) -> Result<Vec<models::Integration>> {
+    let mut builder = client.request(Method::GET, "/api/profile/integrations")?;
     let response = builder.send().await?.error_for_status()?.json().await?;
 
     Ok(response)

--- a/fiberplane-api-client/src/lib.rs
+++ b/fiberplane-api-client/src/lib.rs
@@ -18,6 +18,7 @@ pub(crate) mod models {
     pub(crate) use fiberplane_models::files::*;
     pub(crate) use fiberplane_models::formatting::*;
     pub(crate) use fiberplane_models::front_matter_schemas::*;
+    pub(crate) use fiberplane_models::integrations::*;
     pub(crate) use fiberplane_models::labels::*;
     pub(crate) use fiberplane_models::names::*;
     pub(crate) use fiberplane_models::notebooks::operations::*;

--- a/fiberplane-api-client/src/lib.rs
+++ b/fiberplane-api-client/src/lib.rs
@@ -564,6 +564,14 @@ pub async fn oid_connections_list(client: &ApiClient) -> Result<Vec<models::OidC
     Ok(response)
 }
 
+#[doc = r#"Get a list of all integrations and their status"#]
+pub async fn integrations_get(client: &ApiClient) -> Result<Vec<models::Integration>> {
+    let mut builder = client.request(Method::GET, "/api/profile/integrations")?;
+    let response = builder.send().await?.error_for_status()?.json().await?;
+
+    Ok(response)
+}
+
 #[doc = r#"Retrieve profile image"#]
 pub async fn profile_picture_get(client: &ApiClient) -> Result<bytes::Bytes> {
     let mut builder = client.request(Method::GET, "/api/profile/picture")?;

--- a/fiberplane-api-client/src/lib.rs
+++ b/fiberplane-api-client/src/lib.rs
@@ -570,7 +570,7 @@ pub async fn integrations_get(
     client: &ApiClient,
     page: Option<i32>,
     limit: Option<i32>,
-) -> Result<Vec<models::Integration>> {
+) -> Result<Vec<models::IntegrationSummary>> {
     let mut builder = client.request(Method::GET, "/api/profile/integrations")?;
     if let Some(page) = page {
         builder = builder.query(&[("page", page)]);

--- a/fiberplane-api-client/src/lib.rs
+++ b/fiberplane-api-client/src/lib.rs
@@ -566,8 +566,18 @@ pub async fn oid_connections_list(client: &ApiClient) -> Result<Vec<models::OidC
 }
 
 #[doc = r#"Get a list of all integrations and their status"#]
-pub async fn integrations_get(client: &ApiClient) -> Result<Vec<models::Integration>> {
+pub async fn integrations_get(
+    client: &ApiClient,
+    page: Option<i32>,
+    limit: Option<i32>,
+) -> Result<Vec<models::Integration>> {
     let mut builder = client.request(Method::GET, "/api/profile/integrations")?;
+    if let Some(page) = page {
+        builder = builder.query(&[("page", page)]);
+    }
+    if let Some(limit) = limit {
+        builder = builder.query(&[("limit", limit)]);
+    }
     let response = builder.send().await?.error_for_status()?.json().await?;
 
     Ok(response)

--- a/fiberplane-models/src/integrations.rs
+++ b/fiberplane-models/src/integrations.rs
@@ -37,7 +37,7 @@ pub struct Integration {
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum IntegrationId {
-    GitHub
+    GitHub,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, Display, EnumIter)]

--- a/fiberplane-models/src/integrations.rs
+++ b/fiberplane-models/src/integrations.rs
@@ -13,7 +13,7 @@ use typed_builder::TypedBuilder;
 )]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
-pub struct Integration {
+pub struct IntegrationSummary {
     pub id: IntegrationId,
     pub status: IntegrationStatus,
 
@@ -21,10 +21,6 @@ pub struct Integration {
     pub created_at: Timestamp,
     #[builder(setter(into))]
     pub updated_at: Timestamp,
-
-    #[builder(default, setter(strip_option, into))]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub data: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize, Display, EnumIter)]

--- a/fiberplane-models/src/integrations.rs
+++ b/fiberplane-models/src/integrations.rs
@@ -1,0 +1,59 @@
+use crate::timestamps::Timestamp;
+#[cfg(feature = "fp-bindgen")]
+use fp_bindgen::prelude::Serializable;
+use serde::{Deserialize, Serialize};
+use strum_macros::{Display, EnumIter};
+use typed_builder::TypedBuilder;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
+#[cfg_attr(
+    feature = "fp-bindgen",
+    derive(Serializable),
+    fp(rust_module = "fiberplane_models::integrations")
+)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct Integration {
+    pub id: IntegrationId,
+    pub status: IntegrationStatus,
+
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
+    #[builder(setter(into))]
+    pub updated_at: Timestamp,
+
+    #[builder(default, setter(strip_option, into))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize, Display, EnumIter)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(
+    feature = "fp-bindgen",
+    derive(Serializable),
+    fp(rust_module = "fiberplane_models::integrations")
+)]
+#[non_exhaustive]
+#[serde(rename_all = "lowercase")]
+pub enum IntegrationId {
+    /*
+    GitHub,
+    Zoom,
+    etc...
+    */
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, Display, EnumIter)]
+#[cfg_attr(
+    feature = "fp-bindgen",
+    derive(Serializable),
+    fp(rust_module = "fiberplane_models::integrations")
+)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub enum IntegrationStatus {
+    Connected,
+    Disconnected,
+    AttentionRequired { reason: String }, // todo: check if this gets serialized correctly
+}

--- a/fiberplane-models/src/integrations.rs
+++ b/fiberplane-models/src/integrations.rs
@@ -37,11 +37,7 @@ pub struct Integration {
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum IntegrationId {
-    /*
-    GitHub,
-    Zoom,
-    etc...
-    */
+    GitHub
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, Display, EnumIter)]
@@ -51,9 +47,9 @@ pub enum IntegrationId {
     fp(rust_module = "fiberplane_models::integrations")
 )]
 #[non_exhaustive]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case", tag = "type")]
 pub enum IntegrationStatus {
     Connected,
     Disconnected,
-    AttentionRequired { reason: String }, // todo: check if this gets serialized correctly
+    AttentionRequired { reason: String },
 }

--- a/fiberplane-models/src/lib.rs
+++ b/fiberplane-models/src/lib.rs
@@ -29,6 +29,7 @@ pub mod data_sources;
 pub mod events;
 pub mod files;
 pub mod formatting;
+pub mod integrations;
 pub mod labels;
 pub mod names;
 pub mod notebooks;

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2448,13 +2448,24 @@ components:
         id:
           type: string
           enum:
-            - "TODO"
+            - "github"
         status:
-          type: string
-          enum:
-            - "connected"
-            - "disconnected"
-            - "attentionRequired"
+          type: object
+          required:
+            - type
+          properties:
+            type:
+              type: string
+              enum:
+                - "connected"
+                - "disconnected"
+                - "attention_required"
+            reason:
+              type: string
+              description: |
+                If `type = attention_required`, this field will be
+                populated with a human readable string explaining why
+                attention is required for this peculiar integration
         created_at:
           type: string
           format: date-time

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -3409,6 +3409,9 @@ paths:
       description: "Get a list of all integrations and their status"
       tags:
         - Integrations
+      parameters:
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/limit"
       responses:
         "200":
           description: OK

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2437,7 +2437,7 @@ components:
         location:
           type: string
           description: URL which the user needs to visit
-    integration:
+    integrationSummary:
       type: object
       required:
         - id
@@ -3428,7 +3428,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/integration"
+                  $ref: "#/components/schemas/integrationSummary"
   /api/workspaces/{workspace_id}/pinnednotebooks:
     parameters:
       - $ref: "#/components/parameters/workspace_id"

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2472,9 +2472,6 @@ components:
         updated_at:
           type: string
           format: date-time
-        data:
-          type: object
-          description: Any additional data on the integration, if available
   parameters:
     sortDirection:
       in: query

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2281,6 +2281,33 @@ components:
         location:
           type: string
           description: URL which the user needs to visit
+    integration:
+      type: object
+      required:
+        - id
+        - status
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          enum:
+            - "TODO"
+        status:
+          type: string
+          enum:
+            - "connected"
+            - "disconnected"
+            - "attentionRequired"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        data:
+          type: object
+          description: Any additional data on the integration, if available
   parameters:
     sortDirection:
       in: query
@@ -3212,6 +3239,22 @@ paths:
       responses:
         "200":
           description: OK
+  /api/profile/integrations:
+    get:
+      operationId: integrations_get
+      summary: "Get a list of all integrations and their status"
+      description: "Get a list of all integrations and their status"
+      tags:
+        - Integrations
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/integration"
   /api/workspaces/{workspace_id}/pinnednotebooks:
     parameters:
       - $ref: "#/components/parameters/workspace_id"

--- a/xtask/src/commands/generate_api_client.rs
+++ b/xtask/src/commands/generate_api_client.rs
@@ -22,6 +22,7 @@ pub fn handle_generate_api_client_command() -> TaskResult {
             "fiberplane_models::files::*".to_owned(),
             "fiberplane_models::formatting::*".to_owned(),
             "fiberplane_models::front_matter_schemas::*".to_owned(),
+            "fiberplane_models::integrations::*".to_owned(),
             "fiberplane_models::labels::*".to_owned(),
             "fiberplane_models::names::*".to_owned(),
             "fiberplane_models::proxies::*".to_owned(),

--- a/xtask/src/commands/generate_api_client.rs
+++ b/xtask/src/commands/generate_api_client.rs
@@ -21,6 +21,7 @@ pub fn handle_generate_api_client_command() -> TaskResult {
             "fiberplane_models::events::*".to_owned(),
             "fiberplane_models::files::*".to_owned(),
             "fiberplane_models::formatting::*".to_owned(),
+            "fiberplane_models::integrations::*".to_owned(),
             "fiberplane_models::labels::*".to_owned(),
             "fiberplane_models::names::*".to_owned(),
             "fiberplane_models::proxies::*".to_owned(),


### PR DESCRIPTION
# Description

adds models for integration listing

fixes FP-3386

# Checklist

- [x] The changes have been tested to be backwards compatible.
- [x] The OpenAPI schema and generated client have been updated.
- [x] New models module has been added to api generator xtask
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
* Monofiber: https://github.com/fiberplane/monofiber/pull/193

After merging, please merge related PRs ASAP, so others don't get blocked.
