### PR TITLE
Fix clippy warnings blocking reviewdog in CI

### DIFF
--- a/fiberplane-models/src/front_matter_schemas.rs
+++ b/fiberplane-models/src/front_matter_schemas.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use crate::timestamps::Timestamp;
 use base64uuid::Base64Uuid;
 #[cfg(feature = "fp-bindgen")]
@@ -10,7 +8,7 @@ use strum_macros::Display;
 use typed_builder::TypedBuilder;
 
 /// A floating-point number that can be ordered and compared using Eq.
-///  
+///
 /// It is not compliant to IEEE standard, and NaN is considered greater than
 /// everything and equal to itself.
 ///
@@ -35,7 +33,7 @@ impl Serializable for SerializableEqFloat {
             ts_ty: "number".to_owned(),
             // Not filling the BTreeMap here can be wrong, but as long as fiberplane_models ends up
             // in the dependencies of downstream users, it should be fine.
-            rs_dependencies: BTreeMap::new(),
+            rs_dependencies: std::collections::BTreeMap::new(),
             serde_attrs: Vec::new(),
             ts_declaration: None,
         })

--- a/fiberplane-models/src/lib.rs
+++ b/fiberplane-models/src/lib.rs
@@ -20,7 +20,7 @@ products, including but not limited to:
 
 */
 
-use serde::de::{self, Error, Unexpected, Visitor};
+use serde::de::{Error, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer};
 use std::fmt;
 
@@ -123,7 +123,7 @@ pub trait BindgenSerializable {}
 
 #[cfg(feature = "fp-bindgen")]
 impl<T> BindgenSerializable for T where
-    T: fp_bindgen::prelude::Serializable + for<'de> de::Deserialize<'de>
+    T: fp_bindgen::prelude::Serializable + for<'de> serde::de::Deserialize<'de>
 {
 }
 

--- a/fiberplane-models/src/notebooks/cells.rs
+++ b/fiberplane-models/src/notebooks/cells.rs
@@ -1,6 +1,5 @@
 use crate::blobs::EncodedBlob;
 use crate::formatting::Formatting;
-pub use crate::labels::Label;
 use crate::query_data::{has_query_data, set_query_field, unset_query_field};
 #[cfg(feature = "fp-bindgen")]
 use fp_bindgen::prelude::Serializable;


### PR DESCRIPTION
# Description

This fixes clippy warnings in models, as they block CI that uses review dog with the
strict `-D warnings` flags

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] ~~The changes have been tested to be backwards compatible.~~
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] ~~New models module has been added to api generator xtask~~
- [x] ~~New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [x] ~~The CHANGELOG is updated.~~

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
