### PR TITLE
Add Front Matter Schema names to Template payloads

### DIFF
--- a/fiberplane-models/src/templates.rs
+++ b/fiberplane-models/src/templates.rs
@@ -77,4 +77,11 @@ pub struct Template {
     pub updated_at: Timestamp,
 
     pub parameters: Vec<TemplateParameter>,
+
+    /// The names of the front matter schemas to expand with the template. Names are relevant to the
+    /// workspace in which the template is expanded
+    ///
+    /// The order matters, in that, in case of conflicts, the last [`FrontMatterSchema`]() wins.
+    #[builder(default)]
+    pub front_matter_schema_names: Vec<String>,
 }

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -1221,6 +1221,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/templateParameter"
+        frontMatterSchemaNames:
+          type: array
+          items:
+            type: string
         createdAt:
           type: string
           format: date-time
@@ -1360,6 +1364,10 @@ components:
           type: string
         body:
           type: string
+        frontMatterSchemaNames:
+          type: array
+          items:
+            type: string
     updateTemplate:
       type: object
       properties:
@@ -1367,6 +1375,10 @@ components:
           type: string
         body:
           type: string
+        frontMatterSchemaNames:
+          type: array
+          items:
+            type: string
     trigger:
       type: object
       required:


### PR DESCRIPTION
# Description

This change will allow everyone (including Studio) to reason about expanding
specific front matter schemas with a template. Adding specific front matter
values is out of scope here.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [ ] The changes have been tested to be backwards compatible.
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] ~~New models module has been added to api generator xtask~~
- [x] ~~New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [ ] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
