### PR TITLE
Add updated_at to SubscriberChangedFocusMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ major version hasn't changed.
   controlling the display and the properties of the front matter.
   Each workspace has a list of (editable) associated front matter schemas pickable when
   creating notebooks.
+- `fiberplane-models`: Add `updated_at` to `SubscriberChangedFocusMessage`
 - `fiberplane-api-client`: Add queries to work with front matter schemas associated with
   a workspace.
 

--- a/fiberplane-models/src/realtime.rs
+++ b/fiberplane-models/src/realtime.rs
@@ -785,6 +785,9 @@ pub struct SubscriberChangedFocusMessage {
     /// User's focus within the notebook.
     #[serde(default)]
     pub focus: NotebookFocus,
+
+    #[builder(setter(into))]
+    pub updated_at: Timestamp,
 }
 
 /// A single focus position within a notebook.


### PR DESCRIPTION
# Description

In order to be able to de duplicate subscriber sessions with the same user id, we expose the `updated_at` property on the session so clients can select the last active session.

Fixes FP-3370

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- [x] The OpenAPI schema and generated client have been updated.
- [x] New models module has been added to api generator xtask
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

https://github.com/fiberplane/monofiber/pull/196

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
