### PR TITLE
Fix invalid `getBoundingClientRect` calls

### DIFF
--- a/fiberplane-charts/src/CoreChart/utils.ts
+++ b/fiberplane-charts/src/CoreChart/utils.ts
@@ -28,12 +28,13 @@ export function getCoordinatesForEvent<E extends Element>(
 
     return { x: x / xMax, y: 1 - y / yMax };
   }
+
   const element = event.currentTarget || event.target;
-  if (!element) {
+  if (!(element instanceof Element)) {
     return null;
   }
 
-  const rect = (element as Element).getBoundingClientRect();
+  const rect = element.getBoundingClientRect();
   return {
     x: (event.clientX - rect.left) / xMax,
     y: 1 - (event.clientY - rect.top) / yMax,


### PR DESCRIPTION
# Description

This was the top error in Sentry, even though I suspect the impact was very low: https://fiberplane.sentry.io/issues/4620258427/events/679e11c794c34f43be16f2f42b7a1b90/

# Checklist

- [x] The changes have been tested to be backwards compatible.
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] New models module has been added to api generator xtask~~
- ~~[ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- ~~[ ] The CHANGELOG is updated.~~
