### PR TITLE
`@fiberplane/ui`: Add `lightswitch` as input's type property

### DIFF
--- a/fiberplane-ui/src/components/Input/Input.tsx
+++ b/fiberplane-ui/src/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type HTMLInputTypeAttribute } from "react";
+import { type HTMLInputTypeAttribute, forwardRef } from "react";
 
 import { CheckBox } from "./Checkbox";
 import { LightSwitch } from "./LightSwitch";

--- a/fiberplane-ui/src/components/Input/Input.tsx
+++ b/fiberplane-ui/src/components/Input/Input.tsx
@@ -1,11 +1,13 @@
-import { forwardRef } from "react";
+import { forwardRef, type HTMLInputTypeAttribute } from "react";
 
 import { CheckBox } from "./Checkbox";
 import { LightSwitch } from "./LightSwitch";
 import { RadioButton } from "./RadioButton";
 import { TextInput } from "./TextInput";
 
-type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+type InputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> & {
+  type?: HTMLInputTypeAttribute | "lightswitch";
+};
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   props,


### PR DESCRIPTION
# Description

![Screenshot 2024-01-09 at 11 53 23](https://github.com/fiberplane/fiberplane/assets/33732524/44b23431-7ddc-42d8-9512-b48dc800b1bd)

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

~~- [ ] The changes have been tested to be backwards compatible.~~
~~- [ ] The OpenAPI schema and generated client have been updated.~~
~~- [ ] New models module has been added to api generator xtask~~
~~- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
~~- [ ] The CHANGELOG is updated.~~

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
