### PR TITLE
[FP-3470] Remove unsupported fields from front matter types

### DIFF
--- a/fiberplane-api-client/src/lib.rs
+++ b/fiberplane-api-client/src/lib.rs
@@ -341,7 +341,7 @@ pub async fn file_delete(
     Ok(())
 }
 
-#[doc = r#"Deletes *all* front matter data for notebook. 
+#[doc = r#"Deletes *all* front matter data for notebook.
 If you wish to delete a single key instead of the whole object, use the `patch` endpoint with value: `null`
 "#]
 pub async fn front_matter_delete(

--- a/fiberplane-models/src/front_matter_schemas.rs
+++ b/fiberplane-models/src/front_matter_schemas.rs
@@ -153,12 +153,6 @@ pub struct FrontMatterNumberSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_name: Option<String>,
 
-    /// Whether the field can have multiple values
-    // Skip serialization if the bool is false, and defaults to false, and the setter in typed_builder will set the field to true.
-    #[builder(setter(strip_bool))]
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub multiple: bool,
-
     #[builder(setter(strip_bool))]
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub allow_extra_values: bool,
@@ -255,32 +249,6 @@ pub struct FrontMatterDateTimeSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_name: Option<String>,
 
-    /// Whether the field can have multiple values
-    // Skip serialization if the bool is false, and defaults to false, and the setter in typed_builder will set the field to true.
-    #[builder(setter(strip_bool))]
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub multiple: bool,
-
-    #[builder(setter(strip_bool))]
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub allow_extra_values: bool,
-
-    /// The list of valid "pre-filled" options one can choose for the field.
-    ///
-    /// There is a functional difference between `None` and `Some(Vec::new())`:
-    /// - When `options.is_none()`, that means the current number field should
-    ///   not propose pre-filled values at all: this front matter field is a
-    ///   freeform field
-    /// - When `options == Some(Vec::new())` (arguably with `allow_extra_values` being true),
-    ///   that means that the field is supposed to be a "choose value from an enumerated list"-kind
-    ///   of field, but without any pre-existing values being present.
-    ///
-    /// The difference of intent between those two cases can be used on the front-end side to decide
-    /// how to render the front matter cell
-    #[builder(default, setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub options: Option<Vec<FrontMatterEnumDateTimeValue>>,
-
     #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value: Option<FrontMatterEnumDateTimeValue>,
@@ -301,32 +269,6 @@ pub struct FrontMatterUserSchema {
     #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icon_name: Option<String>,
-
-    /// Whether the field can have multiple values
-    // Skip serialization if the bool is false, and defaults to false, and the setter in typed_builder will set the field to true.
-    #[builder(setter(strip_bool))]
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub multiple: bool,
-
-    #[builder(setter(strip_bool))]
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub allow_extra_values: bool,
-
-    /// The list of valid "pre-filled" options one can choose for the field.
-    ///
-    /// There is a functional difference between `None` and `Some(Vec::new())`:
-    /// - When `options.is_none()`, that means the current number field should
-    ///   not propose pre-filled values at all: this front matter field is a
-    ///   freeform field
-    /// - When `options == Some(Vec::new())` (arguably with `allow_extra_values` being true),
-    ///   that means that the field is supposed to be a "choose value from an enumerated list"-kind
-    ///   of field, but without any pre-existing values being present.
-    ///
-    /// The difference of intent between those two cases can be used on the front-end side to decide
-    /// how to render the front matter cell
-    #[builder(default, setter(into, strip_option))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub options: Option<Vec<FrontMatterEnumBase64UuidValue>>,
 
     #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -1965,8 +1965,6 @@ components:
           type: string
         iconName:
           type: string
-        multiple:
-          type: boolean
         allowExtraValues:
           type: boolean
         options:
@@ -2019,14 +2017,6 @@ components:
           type: string
         iconName:
           type: string
-        multiple:
-          type: boolean
-        allowExtraValues:
-          type: boolean
-        options:
-          type: array
-          items:
-            $ref: "#/components/schemas/frontMatterEnumDateTimeValue"
         defaultValue:
           $ref: "#/components/schemas/frontMatterEnumDateTimeValue"
     frontMatterEnumDateTimeValue:
@@ -2044,14 +2034,6 @@ components:
           type: string
         iconName:
           type: string
-        multiple:
-          type: boolean
-        allowExtraValues:
-          type: boolean
-        options:
-          type: array
-          items:
-            $ref: "#/components/schemas/frontMatterEnumUserValue"
         defaultValue:
           $ref: "#/components/schemas/frontMatterEnumUserValue"
     frontMatterEnumUserValue:
@@ -2975,7 +2957,7 @@ paths:
       operationId: front_matter_delete
       summary: Delete all front matter data for a notebook
       description: |
-        Deletes *all* front matter data for notebook. 
+        Deletes *all* front matter data for notebook.
         If you wish to delete a single key instead of the whole object, use the `patch` endpoint with value: `null`
       tags:
         - Notebooks
@@ -3484,7 +3466,7 @@ paths:
     get:
       operationId: oidc_authorize
       summary: Start the OID auth flow directly (normal sign in)
-      description: | 
+      description: |
         Start the auth flow to authenticate a user (used only with the Studio).
         For authenticating with the API see the Authentication section in the docs
       tags:
@@ -4694,7 +4676,7 @@ paths:
     post:
       operationId: webhook_create
       summary: Create a new webhook
-      description: | 
+      description: |
         Create a new webhook. Upon execution of this route, a test event ("ping") will be sent to the endpoint.
         If sending the ping event fails, the webhook will still be created, but it will be disabled.
         Please check the response of this endpoint to see whenever `enabled` = `false`,
@@ -4723,7 +4705,7 @@ paths:
     patch:
       operationId: webhook_update
       summary: Update an existing webhook
-      description: | 
+      description: |
         Updates an existing webhook. Upon execution of this route, a test event ("ping") will be sent to the endpoint.
         If sending the ping event fails, the webhook will still be updated, but will be disabled.
         Please check the response of this endpoint to see whenever `enabled` = `false`, and if that is the case


### PR DESCRIPTION
# Description

This includes:
- support for multiple dates, or date "enums" (meaning picking from a
  set of predetermined dates)
- support for multiple numbers, and
- support for multiple users, or user "enums"

The support for those options in Studio is not immediately planned, so
we prevent library users from trying unsupported options for now.

Fixes FP-3470
Fixes FP-3432
Fixes FP-3433
Fixes FP-3434

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
      - a matching PR for the private API repo will be necessary
- [x] The OpenAPI schema and generated client have been updated.
- [x] ~~New models module has been added to api generator xtask~~
- [x] ~~New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
