### PR TITLE
Deprecate UpdateNotebookTitle operation

### DIFF
--- a/fiberplane-models/src/notebooks/operations.rs
+++ b/fiberplane-models/src/notebooks/operations.rs
@@ -29,14 +29,14 @@ pub enum Operation {
     ReplaceCells(ReplaceCellsOperation),
     ReplaceText(ReplaceTextOperation),
     UpdateNotebookTimeRange(UpdateNotebookTimeRangeOperation),
+    /// **Deprecated:** Please use `ReplaceText` with `cell_id == TITLE_CELL_ID` instead.
     UpdateNotebookTitle(UpdateNotebookTitleOperation),
     SetSelectedDataSource(SetSelectedDataSourceOperation),
     AddLabel(AddLabelOperation),
     ReplaceLabel(ReplaceLabelOperation),
     RemoveLabel(RemoveLabelOperation),
-    // #[deprecated(
-    //     note = "Full front matter updates should be avoided, granular update operations are better for conflict handling."
-    // )]
+    /// **Deprecated:** Full front matter updates should be avoided, granular update operations are
+    /// better for conflict handling.
     UpdateFrontMatter(UpdateFrontMatterOperation),
     ClearFrontMatter(ClearFrontMatterOperation),
     InsertFrontMatterSchema(InsertFrontMatterSchemaOperation),


### PR DESCRIPTION
# Description

Deprecates `UpdateNotebookTitle` since we can use `ReplaceText` instead.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- ~~[ ] The OpenAPI schema and generated client have been updated.~~
- ~~[ ] New models module has been added to api generator xtask~~
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [ ] The CHANGELOG is updated.
