### PR TITLE
Add 'by name' support to mention front matter schema on notebook creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ major version hasn't changed.
 
 ## [v1.0.0-beta.8] - TBD
 
-- `fiberplane-models`: Add a `front_matter_schemas_by_names` key to the `NewNotebook` payload.
+- `fiberplane-models`: Add a `front_matter_collections` key to the `NewNotebook` payload.
   The extra field will allow an extra way for templates to point to a front matter schema to
   expand into.
 - `fiberplane-models`: Remove (short-lived, unused) `front_matter_schema_names` from `NewTemplate` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ major version hasn't changed.
 
 ## [v1.0.0-beta.8] - TBD
 
+- `fiberplane-models`: Add a `front_matter_schemas_by_names` key to the `NewNotebook` payload.
+  The extra field will allow an extra way for templates to point to a front matter schema to
+  expand into.
+- `fiberplane-models`: Remove (short-lived, unused) `front_matter_schema_names` from `NewTemplate` and
+  `UpdateTemplate` payloads. Consequence of the change above, templates will describe the front
+  matter they use exclusively in their body now, not through extra API handling. Therefore the field
+  is not necessary.
+
 ## [v1.0.0-beta.7] - 2024-01-05
 
 - `fiberplane-charts`: Export some util function and components related to 

--- a/fiberplane-models/src/notebooks/mod.rs
+++ b/fiberplane-models/src/notebooks/mod.rs
@@ -114,20 +114,20 @@ pub struct NewNotebook {
     /// The "inline" front matter schema for the notebook.
     ///
     /// It will always be expanded first and have priority over anything defined in
-    /// `front_matter_schema_by_names`. The keys in common will be ignored.
+    /// `front_matter_collections`. The keys in common will be ignored.
     #[builder(default)]
     #[serde(default)]
     pub front_matter_schema: FrontMatterSchema,
 
     /// A list of front matter schema names that exist in the target workspace.
     ///
-    /// If `front_matter_schema_by_names` and `front_matter_schema` are both mentioned, then:
+    /// If `front_matter_collections` and `front_matter_schema` are both mentioned, then:
     /// - the `front_matter_schema` will be the first elements of the notebook front matter,
     /// - and keys from the named schema that already exist in `front_matter_schema` (or an earlier
     ///   entry in the list) will be ignored.
     #[builder(default)]
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub front_matter_schema_names: Vec<String>,
+    pub front_matter_collections: Vec<Name>,
 }
 
 impl From<Notebook> for NewNotebook {
@@ -140,7 +140,7 @@ impl From<Notebook> for NewNotebook {
             labels: notebook.labels,
             front_matter: notebook.front_matter,
             front_matter_schema: notebook.front_matter_schema,
-            front_matter_schema_names: Vec::new(),
+            front_matter_collections: Vec::new(),
         }
     }
 }

--- a/fiberplane-models/src/notebooks/mod.rs
+++ b/fiberplane-models/src/notebooks/mod.rs
@@ -111,9 +111,23 @@ pub struct NewNotebook {
     #[serde(default)]
     pub front_matter: FrontMatter,
 
+    /// The "inline" front matter schema for the notebook.
+    ///
+    /// It will always be expanded first and have priority over anything defined in
+    /// `front_matter_schema_by_names`. The keys in common will be ignored.
     #[builder(default)]
     #[serde(default)]
     pub front_matter_schema: FrontMatterSchema,
+
+    /// A list of front matter schema names that exist in the target workspace.
+    ///
+    /// If `front_matter_schema_by_names` and `front_matter_schema` are both mentioned, then:
+    /// - the `front_matter_schema` will be the first elements of the notebook front matter,
+    /// - and keys from the named schema that already exist in `front_matter_schema` (or an earlier
+    ///   entry in the list) will be ignored.
+    #[builder(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub front_matter_schema_by_names: Vec<String>,
 }
 
 impl From<Notebook> for NewNotebook {
@@ -126,6 +140,7 @@ impl From<Notebook> for NewNotebook {
             labels: notebook.labels,
             front_matter: notebook.front_matter,
             front_matter_schema: notebook.front_matter_schema,
+            front_matter_schema_by_names: Vec::new(),
         }
     }
 }
@@ -371,27 +386,15 @@ pub struct NewTemplate {
     #[builder(default, setter(into))]
     pub description: String,
 
-    #[builder(default)]
-    pub front_matter_schema_names: Vec<String>,
-
     #[builder(setter(into))]
     pub body: String,
 }
 
 impl NewTemplate {
-    pub fn new(
-        name: Name,
-        description: impl Into<String>,
-        front_matter_schema_names: &[impl ToString],
-        body: impl Into<String>,
-    ) -> Self {
+    pub fn new(name: Name, description: impl Into<String>, body: impl Into<String>) -> Self {
         Self {
             name,
             description: description.into(),
-            front_matter_schema_names: front_matter_schema_names
-                .iter()
-                .map(ToString::to_string)
-                .collect(),
             body: body.into(),
         }
     }
@@ -408,9 +411,6 @@ impl NewTemplate {
 pub struct UpdateTemplate {
     #[builder(default, setter(into, strip_option))]
     pub description: Option<String>,
-
-    #[builder(default, setter(into, strip_option))]
-    pub front_matter_schema_names: Option<Vec<String>>,
 
     #[builder(default, setter(into, strip_option))]
     pub body: Option<String>,

--- a/fiberplane-models/src/notebooks/mod.rs
+++ b/fiberplane-models/src/notebooks/mod.rs
@@ -127,7 +127,7 @@ pub struct NewNotebook {
     ///   entry in the list) will be ignored.
     #[builder(default)]
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub front_matter_schema_by_names: Vec<String>,
+    pub front_matter_schema_names: Vec<String>,
 }
 
 impl From<Notebook> for NewNotebook {
@@ -140,7 +140,7 @@ impl From<Notebook> for NewNotebook {
             labels: notebook.labels,
             front_matter: notebook.front_matter,
             front_matter_schema: notebook.front_matter_schema,
-            front_matter_schema_by_names: Vec::new(),
+            front_matter_schema_names: Vec::new(),
         }
     }
 }

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -49,7 +49,7 @@ components:
           $ref: "#/components/schemas/frontMatter"
         frontMatterSchema:
           $ref: "#/components/schemas/frontMatterSchema"
-        frontMatterSchemaNames:
+        frontMatterCollections:
           type: array
           items:
             type: string

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -49,6 +49,10 @@ components:
           $ref: "#/components/schemas/frontMatter"
         frontMatterSchema:
           $ref: "#/components/schemas/frontMatterSchema"
+        frontMatterSchemaByNames:
+          type: array
+          items:
+            type: string
     notebookCopyDestination:
       type: object
       required:

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -49,7 +49,7 @@ components:
           $ref: "#/components/schemas/frontMatter"
         frontMatterSchema:
           $ref: "#/components/schemas/frontMatterSchema"
-        frontMatterSchemaByNames:
+        frontMatterSchemaNames:
           type: array
           items:
             type: string


### PR DESCRIPTION
# Description

Add support for mentioning front matter schemas by name when creating notebooks.
This is a step towards getting templates to expand with arbitrary front matter schemas.

Fixes FP-3458

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- [x] The OpenAPI schema and generated client have been updated.
- [x] ~~New models module has been added to api generator xtask~~
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
