### PR TITLE
upgrade to sqlx 0.7

### DIFF
--- a/base64uuid/Cargo.toml
+++ b/base64uuid/Cargo.toml
@@ -17,12 +17,7 @@ creation = ["uuid/v4"]
 base64 = "0.13.0"
 fp-bindgen = { workspace = true, optional = true }
 serde = { workspace = true }
-# Currently, sqlx does not export the macros without picking a runtime
-# `runtime-tokio-rustls` can be removed once https://github.com/launchbadge/sqlx/issues/1627 is resolved
-sqlx = { version = "0.6", default-features = false, optional = true, features = [
-    "macros",
-    "runtime-tokio-rustls",
-] }
+sqlx = { version = "0.7.3", default-features = false, optional = true, features = ["macros"] }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 

--- a/fiberplane-models/Cargo.toml
+++ b/fiberplane-models/Cargo.toml
@@ -35,12 +35,7 @@ rmp-serde = "1.0"
 serde = { workspace = true }
 serde_bytes = "0.11"
 serde_json = { workspace = true }
-# Currently, sqlx does not export the macros without picking a runtime
-# `runtime-tokio-rustls` can be removed once https://github.com/launchbadge/sqlx/issues/1627 is resolved
-sqlx = { version = "0.6", default-features = false, optional = true, features = [
-    "macros",
-    "runtime-tokio-rustls",
-] }
+sqlx = { version = "0.7.3", default-features = false, optional = true, features = ["macros"] }
 thiserror = "1.0"
 time = { workspace = true }
 typed-builder = { workspace = true }


### PR DESCRIPTION
# Description

also allows us to get rid of the runtime feature flags as macros are enabled now with just the `macros` feature flag

required for api sqlx 0.7 upgrade

# Checklist

- [x] ~~The changes have been tested to be backwards compatible.~~
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] ~~New models module has been added to api generator xtask~~
- [x] ~~New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [x] ~~The CHANGELOG is updated.~~

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
