### PR TITLE
[FP-3460] Add Front Matter manipulations to templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ major version hasn't changed.
   matter they use exclusively in their body now, not through extra API handling. Therefore the field
   is not necessary.
 - `fiberplane-ui`: Reduce UI library theming complexity & add fallback values.
+- `fiberplane-templates`: Add jsonnet functions in `fiberplane.libsonnet` to allow templates to manipulate
+  front matter when creating a notebook.
+  + `addFrontMatterCollection` and `addFrontMatterCollections` allow to add front matter entries according
+    to (beta) front matter collections living in the workspace that the template is expanded into.
+  + `addFrontMatterValue` and `AddFrontMatterValues` allow to add specific values to front matter entries
+  + `addFrontMatterSchema` is an unstable function that allows to specify front matter entries to add
+    to the notebook inplace. It is currently used to convert a notebook to a template while keeping the
+    front matter information
 
 ## [v1.0.0-beta.7] - 2024-01-05
 

--- a/fiberplane-templates/docs/template_api.md
+++ b/fiberplane-templates/docs/template_api.md
@@ -41,7 +41,7 @@ fp.notebook.new('My Notebook')
         * [`.addFrontMatterCollection(name)`](#notebook.Notebook+addFrontMatterCollection) ⇒ [<code>Notebook</code>](#notebook.Notebook)
         * [`.addFrontMatterCollections(names)`](#notebook.Notebook+addFrontMatterCollections) ⇒ [<code>Notebook</code>](#notebook.Notebook)
         * [`.addFrontMatterSchema(frontMatterSchema)`](#notebook.Notebook+addFrontMatterSchema) ⇒ [<code>Notebook</code>](#notebook.Notebook)
-        * [`.addLabel(key, value)`](#notebook.Notebook+addLabel) ⇒ [<code>Notebook</code>](#notebook.Notebook)
+        * [`.addFrontMatterValue(key, value)`](#notebook.Notebook+addFrontMatterValue) ⇒ [<code>Notebook</code>](#notebook.Notebook)
         * [`.addFrontMatterValues(vals)`](#notebook.Notebook+addFrontMatterValues) ⇒ [<code>Notebook</code>](#notebook.Notebook)
     * [`.new(title)`](#notebook.new) ⇒ [<code>Notebook</code>](#notebook.Notebook)
 
@@ -64,7 +64,7 @@ fp.notebook.new('My Notebook')
     * [`.addFrontMatterCollection(name)`](#notebook.Notebook+addFrontMatterCollection) ⇒ [<code>Notebook</code>](#notebook.Notebook)
     * [`.addFrontMatterCollections(names)`](#notebook.Notebook+addFrontMatterCollections) ⇒ [<code>Notebook</code>](#notebook.Notebook)
     * [`.addFrontMatterSchema(frontMatterSchema)`](#notebook.Notebook+addFrontMatterSchema) ⇒ [<code>Notebook</code>](#notebook.Notebook)
-    * [`.addLabel(key, value)`](#notebook.Notebook+addLabel) ⇒ [<code>Notebook</code>](#notebook.Notebook)
+    * [`.addFrontMatterValue(key, value)`](#notebook.Notebook+addFrontMatterValue) ⇒ [<code>Notebook</code>](#notebook.Notebook)
     * [`.addFrontMatterValues(vals)`](#notebook.Notebook+addFrontMatterValues) ⇒ [<code>Notebook</code>](#notebook.Notebook)
 
 <a name="notebook.Notebook+setTimeRangeRelative"></a>
@@ -199,8 +199,8 @@ notebook.addFrontMatterCollections(['post-mortem', 'opsgenie'])
 <a name="notebook.Notebook+addFrontMatterSchema"></a>
 
 #### `notebook.addFrontMatterSchema(frontMatterSchema)` ⇒ [<code>Notebook</code>](#notebook.Notebook)
-<p>UNSTABLE: this function has no validation and the parameters might change
-Append front matter schema to a notebook inline. The method allows describing the schema
+<p>UNSTABLE: this function has no validation and the parameters might change.</p>
+<p>Append front matter schema to a notebook inline. The method allows describing the schema
 directly in template source.</p>
 
 **Kind**: instance method of [<code>Notebook</code>](#notebook.Notebook)  
@@ -209,9 +209,9 @@ directly in template source.</p>
 | --- | --- | --- |
 | frontMatterSchema | <code>Array.&lt;object&gt;</code> | <p>Front Matter Schema as expected by the API</p> |
 
-<a name="notebook.Notebook+addLabel"></a>
+<a name="notebook.Notebook+addFrontMatterValue"></a>
 
-#### `notebook.addLabel(key, value)` ⇒ [<code>Notebook</code>](#notebook.Notebook)
+#### `notebook.addFrontMatterValue(key, value)` ⇒ [<code>Notebook</code>](#notebook.Notebook)
 <p>Add a single front matter value to the notebook. The value will <em>not</em> appear in the
 notebook unless the front matter <em>schema</em> of the notebook has an entry for the given key.</p>
 

--- a/fiberplane-templates/docs/template_api.md
+++ b/fiberplane-templates/docs/template_api.md
@@ -38,6 +38,11 @@ fp.notebook.new('My Notebook')
         * [`.addCells(cells)`](#notebook.Notebook+addCells) ⇒ [<code>Notebook</code>](#notebook.Notebook)
         * [`.addLabel(key, value)`](#notebook.Notebook+addLabel) ⇒ [<code>Notebook</code>](#notebook.Notebook)
         * [`.addLabels(labels)`](#notebook.Notebook+addLabels) ⇒ [<code>Notebook</code>](#notebook.Notebook)
+        * [`.addFrontMatterCollection(name)`](#notebook.Notebook+addFrontMatterCollection) ⇒ [<code>Notebook</code>](#notebook.Notebook)
+        * [`.addFrontMatterCollections(names)`](#notebook.Notebook+addFrontMatterCollections) ⇒ [<code>Notebook</code>](#notebook.Notebook)
+        * [`.addFrontMatterSchema(frontMatterSchema)`](#notebook.Notebook+addFrontMatterSchema) ⇒ [<code>Notebook</code>](#notebook.Notebook)
+        * [`.addLabel(key, value)`](#notebook.Notebook+addLabel) ⇒ [<code>Notebook</code>](#notebook.Notebook)
+        * [`.addFrontMatterValues(vals)`](#notebook.Notebook+addFrontMatterValues) ⇒ [<code>Notebook</code>](#notebook.Notebook)
     * [`.new(title)`](#notebook.new) ⇒ [<code>Notebook</code>](#notebook.Notebook)
 
 <a name="notebook.Notebook"></a>
@@ -56,6 +61,11 @@ fp.notebook.new('My Notebook')
     * [`.addCells(cells)`](#notebook.Notebook+addCells) ⇒ [<code>Notebook</code>](#notebook.Notebook)
     * [`.addLabel(key, value)`](#notebook.Notebook+addLabel) ⇒ [<code>Notebook</code>](#notebook.Notebook)
     * [`.addLabels(labels)`](#notebook.Notebook+addLabels) ⇒ [<code>Notebook</code>](#notebook.Notebook)
+    * [`.addFrontMatterCollection(name)`](#notebook.Notebook+addFrontMatterCollection) ⇒ [<code>Notebook</code>](#notebook.Notebook)
+    * [`.addFrontMatterCollections(names)`](#notebook.Notebook+addFrontMatterCollections) ⇒ [<code>Notebook</code>](#notebook.Notebook)
+    * [`.addFrontMatterSchema(frontMatterSchema)`](#notebook.Notebook+addFrontMatterSchema) ⇒ [<code>Notebook</code>](#notebook.Notebook)
+    * [`.addLabel(key, value)`](#notebook.Notebook+addLabel) ⇒ [<code>Notebook</code>](#notebook.Notebook)
+    * [`.addFrontMatterValues(vals)`](#notebook.Notebook+addFrontMatterValues) ⇒ [<code>Notebook</code>](#notebook.Notebook)
 
 <a name="notebook.Notebook+setTimeRangeRelative"></a>
 
@@ -154,6 +164,85 @@ notebook.addLabel(key='service', value='api')
 notebook.addLabels({
  service: 'api',
  severity: 'high'
+})
+```
+<a name="notebook.Notebook+addFrontMatterCollection"></a>
+
+#### `notebook.addFrontMatterCollection(name)` ⇒ [<code>Notebook</code>](#notebook.Notebook)
+<p>Add a single front matter collection to the notebook.</p>
+
+**Kind**: instance method of [<code>Notebook</code>](#notebook.Notebook)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| name | <code>string</code> | <p>Name of the front matter collection in the workspace</p> |
+
+**Example**  
+```js
+notebook.addFrontMatterCollection(name='post-mortem')
+```
+<a name="notebook.Notebook+addFrontMatterCollections"></a>
+
+#### `notebook.addFrontMatterCollections(names)` ⇒ [<code>Notebook</code>](#notebook.Notebook)
+<p>Add multiple front matter collections to the notebook.</p>
+
+**Kind**: instance method of [<code>Notebook</code>](#notebook.Notebook)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| names | <code>Array.&lt;string&gt;</code> | <p>Names of the front matter collections in the workspace</p> |
+
+**Example**  
+```js
+notebook.addFrontMatterCollections(['post-mortem', 'opsgenie'])
+```
+<a name="notebook.Notebook+addFrontMatterSchema"></a>
+
+#### `notebook.addFrontMatterSchema(frontMatterSchema)` ⇒ [<code>Notebook</code>](#notebook.Notebook)
+<p>UNSTABLE: this function has no validation and the parameters might change
+Append front matter schema to a notebook inline. The method allows describing the schema
+directly in template source.</p>
+
+**Kind**: instance method of [<code>Notebook</code>](#notebook.Notebook)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| frontMatterSchema | <code>Array.&lt;object&gt;</code> | <p>Front Matter Schema as expected by the API</p> |
+
+<a name="notebook.Notebook+addLabel"></a>
+
+#### `notebook.addLabel(key, value)` ⇒ [<code>Notebook</code>](#notebook.Notebook)
+<p>Add a single front matter value to the notebook. The value will <em>not</em> appear in the
+notebook unless the front matter <em>schema</em> of the notebook has an entry for the given key.</p>
+
+**Kind**: instance method of [<code>Notebook</code>](#notebook.Notebook)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| key | <code>string</code> | <p>Key of the front matter entry</p> |
+| value | <code>string</code> \| <code>number</code> | <p>Front matter value</p> |
+
+**Example**  
+```js
+notebook.addFrontMatterValue(key='status', value='Created')
+```
+<a name="notebook.Notebook+addFrontMatterValues"></a>
+
+#### `notebook.addFrontMatterValues(vals)` ⇒ [<code>Notebook</code>](#notebook.Notebook)
+<p>Add multiple front matter values to the notebook. The value will <em>not</em> appear in the
+notebook unless the front matter <em>schema</em> of the notebook has an entry for the given key.</p>
+
+**Kind**: instance method of [<code>Notebook</code>](#notebook.Notebook)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| vals | <code>object</code> | <p>Map of keys and values</p> |
+
+**Example**  
+```js
+notebook.addFrontMatterValues({
+ status: 'Created',
+ ticket: 23
 })
 ```
 <a name="notebook.new"></a>
@@ -401,7 +490,7 @@ notebook.addCells([
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | intent | <code>string</code> |  | <p>The intent of the new provider cell</p> |
-| title | <code>string</code> |  | <p>Title for the new provider cell</p> |
+| title | <code>string</code> |  | <p>Title for the new provider cell (deprecated)</p> |
 | queryData | <code>string</code> |  | <p>Query data that the provider will understand</p> |
 | readOnly | <code>boolean</code> | <code>false</code> | <p>Whether the cell is locked</p> |
 

--- a/fiberplane-templates/fiberplane.libsonnet
+++ b/fiberplane-templates/fiberplane.libsonnet
@@ -261,7 +261,7 @@ local notebook = {
   new(title):: {
     title: validate.string('title', title),
     timeRange: { minutes: -60 },
-    dataSources: {},
+    selectedDataSources: {},
     labels: [],
     cells: [],
     frontMatter: {},

--- a/fiberplane-templates/fiberplane.libsonnet
+++ b/fiberplane-templates/fiberplane.libsonnet
@@ -430,7 +430,7 @@ local notebook = {
      */
     addFrontMatterCollections(names):: std.foldl(
       function(nb, name)
-        nb.addFrontMatterCollection(validate.string('name', name)),
+        nb.addFrontMatterCollection(name),
       names,
       self
     ),

--- a/fiberplane-templates/fiberplane.libsonnet
+++ b/fiberplane-templates/fiberplane.libsonnet
@@ -264,6 +264,9 @@ local notebook = {
     dataSources: {},
     labels: [],
     cells: [],
+    frontMatter: {},
+    frontMatterSchema: [],
+    frontMatterCollections: [],
     // This is used to generate the cell IDs in the addCell
     // method. It does not appear in the JSON output
     _nextCellId:: 1,
@@ -400,6 +403,86 @@ local notebook = {
       std.objectFields(validate.object('labels', labels)),
       self
     ),
+
+    /**
+     * Add a single front matter collection to the notebook.
+     *
+     * @function notebook.Notebook#addFrontMatterCollection
+     * @param {string} name - Name of the front matter collection in the workspace
+     * @returns {notebook.Notebook}
+     *
+     * @example notebook.addFrontMatterCollection(name='post-mortem')
+     */
+    addFrontMatterCollection(name):: self {
+      frontMatterCollections+: [
+        validate.string('name', name),
+      ],
+    },
+
+    /**
+     * Add multiple front matter collections to the notebook.
+     *
+     * @function notebook.Notebook#addFrontMatterCollections
+     * @param {Array.<string>} names - Names of the front matter collections in the workspace
+     * @returns {notebook.Notebook}
+     *
+     * @example notebook.addFrontMatterCollections(['post-mortem', 'opsgenie'])
+     */
+    addFrontMatterCollections(names):: std.foldl(
+      function(nb, name)
+        nb.addFrontMatterCollection(validate.string('name', name)),
+      names,
+      self
+    ),
+
+    /**
+     * UNSTABLE: this function has no validation and the parameters might change
+     * Append front matter schema to a notebook inline. The method allows describing the schema
+     * directly in template source.
+     *
+     * @function notebook.Notebook#addFrontMatterSchema
+     * @param {Array.<object>} frontMatterSchema - Front Matter Schema as expected by the API
+     * @returns {notebook.Notebook}
+     */
+    addFrontMatterSchema(fMSchema):: self {
+      frontMatterSchema+: fMSchema,
+    },
+
+    /**
+     * Add a single front matter value to the notebook. The value will _not_ appear in the
+     * notebook unless the front matter _schema_ of the notebook has an entry for the given key.
+     *
+     * @function notebook.Notebook#addLabel
+     * @param {string} key - Key of the front matter entry
+     * @param {string | number} value - Front matter value
+     * @returns {notebook.Notebook}
+     *
+     * @example notebook.addFrontMatterValue(key='status', value='Created')
+     */
+    addFrontMatterValue(key, value):: self {
+      frontMatter+: { key: value },
+    },
+
+    /**
+     * Add multiple front matter values to the notebook. The value will _not_ appear in the
+     * notebook unless the front matter _schema_ of the notebook has an entry for the given key.
+     *
+     * @function notebook.Notebook#addFrontMatterValues
+     * @param {object} vals - Map of keys and values
+     * @returns {notebook.Notebook}
+     *
+     * @example notebook.addFrontMatterValues({
+     *  status: 'Created',
+     *  ticket: 23
+     * })
+     */
+    addFrontMatterValues(vals):: std.foldl(
+      function(nb, key)
+        nb.addFrontMatterValue(key, vals[key]),
+      std.objectFields(validate.object('vals', vals)),
+      self
+    ),
+
   },
 };
 

--- a/fiberplane-templates/fiberplane.libsonnet
+++ b/fiberplane-templates/fiberplane.libsonnet
@@ -460,7 +460,7 @@ local notebook = {
      * @example notebook.addFrontMatterValue(key='status', value='Created')
      */
     addFrontMatterValue(key, value):: self {
-      frontMatter+: { key: value },
+      frontMatter+: { [key]: value },
     },
 
     /**

--- a/fiberplane-templates/fiberplane.libsonnet
+++ b/fiberplane-templates/fiberplane.libsonnet
@@ -436,7 +436,8 @@ local notebook = {
     ),
 
     /**
-     * UNSTABLE: this function has no validation and the parameters might change
+     * UNSTABLE: this function has no validation and the parameters might change.
+     *
      * Append front matter schema to a notebook inline. The method allows describing the schema
      * directly in template source.
      *
@@ -452,7 +453,7 @@ local notebook = {
      * Add a single front matter value to the notebook. The value will _not_ appear in the
      * notebook unless the front matter _schema_ of the notebook has an entry for the given key.
      *
-     * @function notebook.Notebook#addLabel
+     * @function notebook.Notebook#addFrontMatterValue
      * @param {string} key - Key of the front matter entry
      * @param {string | number} value - Front matter value
      * @returns {notebook.Notebook}

--- a/fiberplane-templates/src/convert/mod.rs
+++ b/fiberplane-templates/src/convert/mod.rs
@@ -93,6 +93,29 @@ pub fn notebook_to_template(notebook: impl Into<NewNotebook>) -> String {
         writer.println("})");
     }
 
+    // Add front matter
+    if !notebook.front_matter.is_empty() {
+        writer.println(".addFrontMatterValues({");
+        for (fm_key, fm_value) in notebook.front_matter {
+            writer.println(format!(
+                "{}: {},",
+                escape_string(fm_key),
+                serde_json::to_string(&fm_value).expect("A JSON Value is always serializable")
+            ));
+        }
+        writer.println("})");
+    }
+
+    // Add front matter schema
+    if !notebook.front_matter_schema.is_empty() {
+        writer.println("// If the front matter schema comes from a known collection, you can replace the next call with .addFrontMatterCollection('name')");
+        writer.println(format!(
+            ".addFrontMatterSchema({})",
+            serde_json::to_string_pretty(&notebook.front_matter_schema.0)
+                .expect("A Front matter schema is always serializable."),
+        ));
+    }
+
     // Add selected data sources
     for (provider_type, data_source) in notebook.selected_data_sources.iter() {
         if let Some(proxy_name) = &data_source.proxy_name {


### PR DESCRIPTION
# Description

- Add front matter support in templates (libsonnet)
- Fix name of data sources field in notebooks
- Fix bad interpolation of key name in front matter helper function
- Generate template docs

The extra functions in libsonnet allow to expand templates with pre-determined front matter

Fixes FP-3460

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- [x] The OpenAPI schema and generated client have been updated.
- [x] New models module has been added to api generator xtask
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [ ] The CHANGELOG is updated.