### PR TITLE
`@fiberplane/ui`: Button & text input fix

### DIFF
--- a/fiberplane-ui/src/components/Button.tsx
+++ b/fiberplane-ui/src/components/Button.tsx
@@ -71,7 +71,7 @@ export const buttonStyling = css<StyledButtonTransientProps>(
       /* reset default button styles */
 
       font: var(--font-buttons-md, 500 14px / 16px Inter);
-      max-height: 36px;
+      min-height: 36px;
 
       display: flex;
       justify-content: center;

--- a/fiberplane-ui/src/components/Button.tsx
+++ b/fiberplane-ui/src/components/Button.tsx
@@ -178,7 +178,7 @@ function getButtonStyle(buttonStyle: ButtonStyle) {
         border: 1px solid transparent;
 
         &:hover {
-          color: var(--color-button-primary-fg-default, #fff);
+          color: var(--color-fg-default, #000);
         }
 
         &:focus,

--- a/fiberplane-ui/src/components/Input/TextInput.ts
+++ b/fiberplane-ui/src/components/Input/TextInput.ts
@@ -7,6 +7,7 @@ export const TextInput = styled.input`
   color: var(--color-input-fg-input, #000);
   padding: 6px 12px;
   outline: none;
+  min-height: 36px;
   font: var(--font-body-md-regular, 400 14px / 24px Inter);
   box-shadow: var(--shadow-xxs, 0px 1px 2px 0px rgb(0 0 0 / 5%));
 


### PR DESCRIPTION
# Description

Set `min-height` on both buttons & text input.
Also fixes hover color of the button's `tertiary-color` variant.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

~~- [ ] The changes have been tested to be backwards compatible.~~
~~- [ ] The OpenAPI schema and generated client have been updated.~~
~~- [ ] New models module has been added to api generator xtask~~
~~- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
~~- [ ] The CHANGELOG is updated.~~

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
