### PR TITLE
Add support for "multiple" in user schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ major version hasn't changed.
 
 ## [v1.0.0-beta.8] - TBD
 
+- `fiberplane-models`: User schema for front-matter now has the multiple property, so multiple users can be selected
 - `fiberplane-models`: Add a `front_matter_collections` key to the `NewNotebook` payload.
   The extra field will allow an extra way for templates to point to a front matter schema to
   expand into.

--- a/fiberplane-models/src/front_matter_schemas.rs
+++ b/fiberplane-models/src/front_matter_schemas.rs
@@ -273,10 +273,16 @@ pub struct FrontMatterUserSchema {
     #[builder(default, setter(into, strip_option))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value: Option<FrontMatterEnumBase64UuidValue>,
+
+    /// Whether the field can have multiple values
+    // Skip serialization if the bool is false, and defaults to false, and the setter in typed_builder will set the field to true.
+    #[builder(setter(strip_bool))]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub multiple: bool,
 }
 
 // NOTE: The cleaner way would be to have a generic type FrontMatterEnumValue<T>,
-// but it's impossible to _conditionnally_ add the `Serializable` trait bound on
+// but it's impossible to _conditionally_ add the `Serializable` trait bound on
 // the inner type T only when there is the "fp-bindgen" feature.
 
 // NOTE: The reason those are struct instead of "just" being the

--- a/fiberplane-models/src/front_matter_schemas.rs
+++ b/fiberplane-models/src/front_matter_schemas.rs
@@ -204,7 +204,8 @@ pub struct FrontMatterStringSchema {
     pub icon_name: Option<String>,
 
     /// Whether the field can have multiple values
-    // Skip serialization if the bool is false, and defaults to false, and the setter in typed_builder will set the field to true.
+    // Skip serialization if the bool is false, and defaults to false, and the setter in typed_builder
+    // will set the field to true.
     #[builder(setter(strip_bool))]
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub multiple: bool,

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2038,6 +2038,8 @@ components:
           type: string
         iconName:
           type: string
+        multiple:
+          type: boolean
         defaultValue:
           $ref: "#/components/schemas/frontMatterEnumUserValue"
     frontMatterEnumUserValue:


### PR DESCRIPTION
# Description

Users have asked to be able to select multiple users in front-matter. This means an updated to the schema was required to allow once more for the property "multiple"

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- [ ] ~The OpenAPI schema and generated client have been updated.~
- [ ] ~New models module has been added to api generator xtask~
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
