### PR TITLE
[FP-3502] Add route to delete a front matter collection from a workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ major version hasn't changed.
 
 ## [v1.0.0-beta.10] - TBD
 
+- `API` schema: Add routes to manipulate the front matter collections in a workspace (a saved front matter
+  schema with an attached name).
+- `fiberplane-api-client`: Add methods to manipulate the front matter collections in a workspace.
+
 ## [v1.0.0-beta.9] - 2024-02-05
 
 - `fiberplane-models`: User schema for front-matter now has the multiple property, so multiple users can be selected

--- a/fiberplane-api-client/src/lib.rs
+++ b/fiberplane-api-client/src/lib.rs
@@ -1116,6 +1116,25 @@ pub async fn workspace_front_matter_schemas_get_by_name(
     Ok(response)
 }
 
+#[doc = r#"Delete a front matter schema defined in the workspace"#]
+pub async fn workspace_front_matter_schemas_delete(
+    client: &ApiClient,
+    workspace_id: base64uuid::Base64Uuid,
+    front_matter_schema_name: &str,
+) -> Result<()> {
+    let mut builder = client.request(
+        Method::DELETE,
+        &format!(
+            "/api/workspaces/{workspace_id}/front_matter_schemas/{front_matter_schema_name}",
+            workspace_id = workspace_id,
+            front_matter_schema_name = front_matter_schema_name,
+        ),
+    )?;
+    let response = builder.send().await?.error_for_status()?;
+
+    Ok(())
+}
+
 #[doc = r#"Retrieves a list of pending workspace invitations"#]
 pub async fn workspace_invite_get(
     client: &ApiClient,

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -4944,3 +4944,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/frontMatterSchema"
+    delete:
+      operationId: workspace_front_matter_schemas_delete
+      summary: Delete a front matter schema defined in the workspace
+      description: Delete a front matter schema defined in the workspace
+      tags:
+        - Front Matter Schemas
+      responses:
+        "200":
+          description: OK.


### PR DESCRIPTION
# Description

Add a forgotten endpoint to delete a front matter collection from a
workspace. Management of them was only `CRU` before, not `CRUD`.

Fixes FP-3502

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- [x] The OpenAPI schema and generated client have been updated.
- [x] ~~New models module has been added to api generator xtask~~
- [x] ~~New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
