### PR TITLE
Bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ crates do not strictly follow _SemVer_ although their versioning remains
 _compatible with_ SemVer, i.e. they will not contain breaking changes if the
 major version hasn't changed.
 
-## [v1.0.0-beta.8] - TBD
+## [v1.0.0-beta.9] - TBD
+
+## [v1.0.0-beta.8] - 2024-02-05
 
 - `fiberplane-models`: Add a `front_matter_collections` key to the `NewNotebook` payload.
   The extra field will allow an extra way for templates to point to a front matter schema to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -24,19 +24,19 @@ repository = "https://github.com/fiberplane/fiberplane"
 rust-version = "1.64"
 
 [workspace.dependencies]
-base64uuid = { version = "1.0.0", path = "base64uuid", default-features = false }
+base64uuid = { version = "1.1.0", path = "base64uuid", default-features = false }
 bytes = { version = "1", features = ["serde"] }
 fp-bindgen = { version = "3.0.0" }
 fp-bindgen-support = { version = "3.0.0" }
-fiberplane = { version = "1.0.0-beta.8", path = "fiberplane" }
-fiberplane-api-client = { version = "1.0.0-beta.8", path = "fiberplane-api-client" }
+fiberplane = { version = "1.0.0-beta.9", path = "fiberplane" }
+fiberplane-api-client = { version = "1.0.0-beta.9", path = "fiberplane-api-client" }
 fiberplane-ci = { version = "0.1.0", path = "fiberplane-ci" }
-fiberplane-markdown = { version = "1.0.0-beta.8", path = "fiberplane-markdown" }
-fiberplane-models = { version = "1.0.0-beta.8", path = "fiberplane-models" }
+fiberplane-markdown = { version = "1.0.0-beta.9", path = "fiberplane-markdown" }
+fiberplane-models = { version = "1.0.0-beta.9", path = "fiberplane-models" }
 fiberplane-openapi-rust-gen = { version = "0.1.0", path = "fiberplane-openapi-rust-gen" }
-fiberplane-provider-bindings = { version = "2.0.0-beta.8", path = "fiberplane-provider-protocol/fiberplane-provider-bindings" }
-fiberplane-provider-runtime = { version = "2.0.0-beta.8", path = "fiberplane-provider-protocol/fiberplane-provider-runtime" }
-fiberplane-templates = { version = "1.0.0-beta.8", path = "fiberplane-templates" }
+fiberplane-provider-bindings = { version = "2.0.0-beta.9", path = "fiberplane-provider-protocol/fiberplane-provider-bindings" }
+fiberplane-provider-runtime = { version = "2.0.0-beta.9", path = "fiberplane-provider-protocol/fiberplane-provider-runtime" }
+fiberplane-templates = { version = "1.0.0-beta.9", path = "fiberplane-templates" }
 insta = { version = "1.31.0" }
 once_cell = { version = "1.12" }
 serde = { version = "1", features = ["derive"] }

--- a/base64uuid/Cargo.toml
+++ b/base64uuid/Cargo.toml
@@ -2,7 +2,7 @@
 name = "base64uuid"
 description = "Type for representing base64url-encoded UUIDs"
 readme = "README.md"
-version = "1.0.0"
+version = "1.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/fiberplane-markdown/Cargo.toml
+++ b/fiberplane-markdown/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 
 [dependencies]
 fiberplane-models = { workspace = true }

--- a/fiberplane-models/Cargo.toml
+++ b/fiberplane-models/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 
 [lib]
 crate-type = ["lib"]

--- a/fiberplane-provider-protocol/fiberplane-provider-bindings/Cargo.toml
+++ b/fiberplane-provider-protocol/fiberplane-provider-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiberplane-provider-bindings"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 authors = { workspace = true }
 edition = "2018"
 description = "Fiberplane Provider protocol bindings"

--- a/fiberplane-provider-protocol/fiberplane-provider-runtime/Cargo.toml
+++ b/fiberplane-provider-protocol/fiberplane-provider-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fiberplane-provider-runtime"
 description = "Wasmer runtime for Fiberplane Providers"
 readme = "README.md"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/fiberplane-templates/Cargo.toml
+++ b/fiberplane-templates/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 
 [features]
 default = ["convert", "expand", "examples"]

--- a/fiberplane/Cargo.toml
+++ b/fiberplane/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.8"
+version = "1.0.0-beta.9"
 
 [lib]
 crate-type = ["lib"]

--- a/mondrian-charts/Cargo.toml
+++ b/mondrian-charts/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 keywords = ["chart", "charts", "metrics", "prometheus", "opentelemetry"]
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "0.6.0"
+version = "0.7.0"
 
 [features]
 default = ["fiberplane", "image"]


### PR DESCRIPTION
This PR bumps the version numbers so they match the next release.
Please verify the version numbers are correct, and update the CHANGELOG manually. You
should merge this PR ASAP, but no later than before the next release cycle starts.

# Checklist

- [x] Version numbers are correct
- [x] `CHANGELOG.md` has been updated