### PR TITLE
Fix typescript test on CI

### DIFF
--- a/.github/workflows/test_typescript.yml
+++ b/.github/workflows/test_typescript.yml
@@ -22,12 +22,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --no-immutable
 
-      - name: Build packages
-        run: yarn build
-        
       - name: Verify dist/ folders are not checked in
         run: yarn test-dist
 
+      - name: Build packages
+        run: yarn build
+        
       - name: Linting and formatting
         # Skip on main, since it's not critical and should've already been
         # checked before merging

--- a/.github/workflows/test_typescript.yml
+++ b/.github/workflows/test_typescript.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --no-immutable
 
+      - name: Build packages
+        run: yarn build
+        
       - name: Verify dist/ folders are not checked in
         run: yarn test-dist
 


### PR DESCRIPTION
# Description

Recently the ~@fiberplane/ui~ @fiberplane/hooks package was added as a dependency for @fiberplane/charts. However this resulted in the typescript checks to fail on CI because the typescript definitions could not be found. 

This PR adds a build step