### PR TITLE
`@fiberplane/hooks`: Add `useMedia` & `useThemeSelect` hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ major version hasn't changed.
   + `addFrontMatterSchema` is an unstable function that allows to specify front matter entries to add
     to the notebook inplace. It is currently used to convert a notebook to a template while keeping the
     front matter information
-- Add `fiberplane-hooks`: Add hook library shipping three initial hooks (`useHandler`, `useKeyPressEvent`, `useLocalStorage`)
+- Add `fiberplane-hooks`: Add hook library shipping three initial hooks
+  (`useHandler`, `useKeyPressEvent`, `useLocalStorage`, `useMedia`, `useThemeSwitch`)
 
 ## [v1.0.0-beta.7] - 2024-01-05
 

--- a/fiberplane-hooks/package.json
+++ b/fiberplane-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiberplane/hooks",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Hooks for Fiberplane",
   "author": "Fiberplane <info@fiberplane.com>",
   "license": "MIT OR Apache-2.0",

--- a/fiberplane-hooks/src/index.ts
+++ b/fiberplane-hooks/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./useHandler";
 export * from "./useKeyPressEvent";
 export * from "./useLocalStorage";
+export * from "./useMedia";
+export * from "./useThemeSelect";

--- a/fiberplane-hooks/src/useMedia.ts
+++ b/fiberplane-hooks/src/useMedia.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns whether the current window matches the given
+ * media query.
+ * @returns `true` if the media query matches, `false` otherwise.
+ * @example
+ * const isWide = useMedia("(min-width: 600px)");
+ */
+export function useMedia(query: string) {
+  const [matches, setState] = useState(true);
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(query);
+
+    const onChange = () => setState(mediaQueryList.matches);
+    mediaQueryList.addEventListener("change", onChange);
+
+    setState(mediaQueryList.matches);
+
+    return () => {
+      mediaQueryList.removeEventListener("change", onChange);
+    };
+  }, [query]);
+
+  return matches;
+}

--- a/fiberplane-hooks/src/useThemeSelect.ts
+++ b/fiberplane-hooks/src/useThemeSelect.ts
@@ -1,0 +1,74 @@
+import { useEffect } from "react";
+import { useLocalStorage } from "./useLocalStorage";
+import { useMedia } from "./useMedia";
+
+type Theme = "dark" | "light";
+
+/**
+ * Returns the current theme and getters & setters for changing the theme. It
+ * stores the theme in localStorage if it's not the system's preferred color
+ * scheme.
+ */
+export function useThemeSelect() {
+  const [storedTheme, setStoredTheme] = useLocalStorage<Theme | null>(
+    "theme",
+    null,
+  );
+
+  const systemPrefersDarkTheme = useMedia("(prefers-color-scheme: dark)");
+  const systemDefaultTheme: Theme = systemPrefersDarkTheme ? "dark" : "light";
+
+  const setToSystemTheme = () => setStoredTheme(null);
+  const setThemePreference = (theme: Theme) => setStoredTheme(theme);
+
+  // The computed theme value. Either the stored (and validated), or system's
+  // default theme.
+  const theme: Theme =
+    storedTheme && isValidTheme(storedTheme) ? storedTheme : systemDefaultTheme;
+
+  useEffect(() => {
+    // By setting `data-switching` we can apply a transition to the theme change
+    // in CSS.
+    document.body.dataset.switching = "true";
+    const listenerId = setTimeout(() => {
+      document.body.dataset.switching = "false";
+    }, 100);
+
+    // Set the theme on the `document.body` element. If there's no stored theme,
+    // we remove the `data-theme` attribute so the system's preferred color
+    // scheme is used.
+    document.body.dataset.theme = storedTheme ? theme : "";
+
+    return () => {
+      clearTimeout(listenerId);
+    };
+  }, [theme, storedTheme]);
+
+  return {
+    /**
+     * Either `dark` or `light`, regardless of it's the system or user-selected
+     * preference.
+     */
+    currentTheme: theme,
+    /**
+     * `true` if the theme is the system's preferred color scheme, `false`
+     * otherwise.
+     */
+    isSystemPreference: !storedTheme,
+    /**
+     * When called, sets the theme to the given value and stores it in
+     * `localStorage`.
+     * @param theme The theme to set: either `dark` or `light`.
+     */
+    setThemePreference,
+    /**
+     * When called, sets the theme to the system's preferred color scheme &
+     * removes the stored theme preference from `localStorage`.
+     */
+    setToSystemTheme,
+  };
+}
+
+function isValidTheme(theme: string): theme is Theme {
+  return theme === "dark" || theme === "light";
+}


### PR DESCRIPTION
# Description

Introduces `useMedia` & `useThemeSelect` hooks

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

~~- [ ] The changes have been tested to be backwards compatible.~~
~~- [ ] The OpenAPI schema and generated client have been updated.~~
~~- [ ] New models module has been added to api generator xtask~~
~~- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
