### PR TITLE
`@fiberplane/hooks`: Feature hooks

### DIFF
--- a/fiberplane-charts/rollup.config.ts
+++ b/fiberplane-charts/rollup.config.ts
@@ -13,10 +13,11 @@ const config = defineConfig([
       compact: true,
     },
     external: [
+      "@fiberplane/hooks",
       "framer-motion",
+      "react-window",
       "react",
       "react/jsx-runtime",
-      "react-window",
       "styled-components",
       "throttle-debounce",
     ],

--- a/fiberplane-hooks/src/features.ts
+++ b/fiberplane-hooks/src/features.ts
@@ -22,7 +22,7 @@ import { useLocalStorage } from "./useLocalStorage";
 export function getFeatureHooks<const F extends string>(FEATURES: Array<F>) {
   const FEATURES_KEY = "features";
 
-  type Feature = (typeof FEATURES)[number];
+  type Feature = typeof FEATURES[number];
 
   function isFeature(feature: string): feature is Feature {
     return FEATURES.includes(feature as Feature);

--- a/fiberplane-hooks/src/features.ts
+++ b/fiberplane-hooks/src/features.ts
@@ -1,0 +1,193 @@
+import { useMemo } from "react";
+import { useEffectOnce } from "./useEffectOnce";
+import { useLocalStorage } from "./useLocalStorage";
+
+/**
+ * Accepts an array of feature names and returns hooks for working with them.
+ * @param features An array of feature names
+ * @returns An object containing hooks for working with feature flags:
+ * - `useFeatures` - A hook that returns the enabled state of all features and a
+ * setter for changing it.
+ * - `useFeature` - A hook that accepts a supported feature name and returns
+ * both its enabled state and a setter for changing the state.
+ * - `useFeaturesFromSearchParams` - A hook that handles the initial state of
+ * features based on the query params. This hook should only be called once on
+ * app load, and filters out unsupported features.
+ * @example
+ * import { getFeatureHooks } from "@fiberplane/hooks";
+ *
+ * const { useFeature, useFeatures, useFeaturesFromSearchParams } =
+ *   getFeatureHooks(["experimental-nav", "unstable-feature"]);
+ */
+export function getFeatureHooks<const F extends string>(FEATURES: Array<F>) {
+  const FEATURES_KEY = "features";
+
+  type Feature = (typeof FEATURES)[number];
+
+  function isFeature(feature: string): feature is Feature {
+    return FEATURES.includes(feature as Feature);
+  }
+
+  type Features = {
+    /**
+     * Indicates whether (beta) features are enabled or not. Regardless of
+     * individual feature flags' enabled state, this property determines whether
+     * the app should enable features or not.
+     */
+    enabled: boolean;
+    features: Array<{
+      name: Feature;
+      enabled: boolean;
+    }>;
+  };
+
+  const initialFeatures: Features = {
+    enabled: false,
+    features: FEATURES.map((name) => ({
+      name,
+      enabled: false,
+    })),
+  };
+
+  function useFeatures() {
+    const [storedFeatures, setStoredFeatures] = useValidStoredFeatures();
+    const enableFeatures = storedFeatures.enabled;
+
+    const setEnableFeatures = (enabled: boolean) => {
+      if (enabled) {
+        setStoredFeatures({
+          ...storedFeatures,
+          enabled,
+        });
+        return;
+      }
+
+      // When features are disabled, we fall back to the initial feature state
+      setStoredFeatures(initialFeatures);
+    };
+
+    return [enableFeatures, setEnableFeatures] as const;
+  }
+
+  /**
+   * Hook that accepts a supported feature name and returns both its enabled
+   * state and a setter for changing the state.
+   */
+  function useFeature(feature: Feature) {
+    const [{ enabled: featuresEnabled, features }, setStoredFeatures] =
+      useValidStoredFeatures();
+
+    const isFeatureEnabled = useMemo(() => {
+      const storedFeature = features.find(({ name }) => name === feature);
+      if (!storedFeature) {
+        return false;
+      }
+
+      return featuresEnabled && storedFeature.enabled;
+    }, [feature, features, featuresEnabled]);
+
+    const setIsFeatureEnabled = (featureEnabled: boolean) => {
+      const updatedFeatures = FEATURES.map((key) => {
+        const existing = features.find(({ name }) => name === key);
+
+        const enabled =
+          key === feature ? featureEnabled : existing?.enabled ?? false;
+
+        return {
+          name: key,
+          enabled,
+        };
+      });
+
+      setStoredFeatures({
+        enabled: featuresEnabled,
+        features: updatedFeatures,
+      });
+    };
+
+    return [isFeatureEnabled, setIsFeatureEnabled] as const;
+  }
+
+  /**
+   * Hook that handles the initial state of features based on the query params.
+   * This hook should only be called once on app load, and filters out
+   * unsupported features.
+   */
+  function useFeaturesFromSearchParams() {
+    const [{ features: validStoredFeatures }, setStoredFeatures] =
+      useValidStoredFeatures();
+
+    const searchParams = new URLSearchParams(window.location.search);
+    const parameterFeatures = searchParams.get(FEATURES_KEY)?.split(",") || [];
+    const validFeatures = new Set(parameterFeatures.filter(isFeature));
+
+    // As the localStorage features aren't updated immediately on initial load,
+    // we use an empty array as a fallback. We can remove this fallback once we
+    // get rid of the temporary hook below.
+    const updatedFeatures = (validStoredFeatures || []).map((storedFeature) => {
+      if (validFeatures.has(storedFeature.name)) {
+        return {
+          ...storedFeature,
+          enabled: true,
+        };
+      }
+
+      return storedFeature;
+    });
+
+    useEffectOnce(() => {
+      if (validFeatures.size === 0) {
+        return;
+      }
+
+      setStoredFeatures({
+        enabled: true,
+        features: updatedFeatures,
+      });
+    });
+  }
+
+  /**
+   * Temporary hook to handle the transition from the old feature to the new
+   * feature state. As we're using the same key for both, we need to handle both
+   * cases.
+   */
+  function useValidStoredFeatures() {
+    const [features, setFeatures] = useLocalStorage<Features>(
+      FEATURES_KEY,
+      initialFeatures,
+    );
+
+    if (Array.isArray(features)) {
+      const validFeatures = new Set(features.filter(isFeature));
+
+      setFeatures({
+        enabled: validFeatures.size > 0,
+        features: FEATURES.map((name) => ({
+          name,
+          enabled: validFeatures.has(name),
+        })),
+      });
+    }
+
+    return [features, setFeatures] as const;
+  }
+
+  return {
+    /**
+     * Returns the enabled state of all features and a setter for changing it.
+     */
+    useFeatures,
+    /**
+     * Accepts a supported feature name and returns both its enabled state and a
+     * setter for changing the state.
+     */
+    useFeature,
+    /**
+     * Handles the initial state of features based on the query params. This
+     * hook should only be called once on app load, and filters out unsupported
+     * features.
+     */
+    useFeaturesFromSearchParams,
+  };
+}

--- a/fiberplane-hooks/src/index.ts
+++ b/fiberplane-hooks/src/index.ts
@@ -1,3 +1,5 @@
+export * from "./features";
+export * from "./useEffectOnce";
 export * from "./useHandler";
 export * from "./useKeyPressEvent";
 export * from "./useLocalStorage";

--- a/fiberplane-hooks/src/useEffectOnce.ts
+++ b/fiberplane-hooks/src/useEffectOnce.ts
@@ -1,0 +1,9 @@
+import { EffectCallback, useEffect } from "react";
+
+/**
+ * Run a callback once when the component mounts.
+ * @param effect Callback to run once
+ */
+export function useEffectOnce(effect: EffectCallback) {
+  useEffect(effect, []);
+}

--- a/fiberplane-hooks/src/useEffectOnce.ts
+++ b/fiberplane-hooks/src/useEffectOnce.ts
@@ -1,9 +1,11 @@
 import { EffectCallback, useEffect } from "react";
 
+const noDeps: Array<void> = [];
+
 /**
  * Run a callback once when the component mounts.
  * @param effect Callback to run once
  */
 export function useEffectOnce(effect: EffectCallback) {
-  useEffect(effect, []);
+  useEffect(effect, noDeps);
 }


### PR DESCRIPTION
# Description

Adds a helper function that takes an array of feature names, and returns feature fully typed features hooks.
This allows for using the helper function like so:

```tsx
// src/hooks/features.ts
import { getFeatureHooks } from "@fiberplane/hooks";

export const { useFeature, useFeatures, useFeaturesFromSearchParams } =
  getFeatureHooks(["feature-1", "feature-2"]);

```

Also includes a fix for Rollup in `fiberplane-charts` as the hooks library wasn't listed as an external dependency.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

~~- [ ] The changes have been tested to be backwards compatible.~~
~~- [ ] The OpenAPI schema and generated client have been updated.~~
~~- [ ] New models module has been added to api generator xtask~~
~~- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [ ] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
