### PR TITLE
remove pagination from integrations listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ major version hasn't changed.
 - `API` schema: Add routes to manipulate the front matter collections in a workspace (a saved front matter
   schema with an attached name).
 - `fiberplane-api-client`: Add methods to manipulate the front matter collections in a workspace.
+- `fiberplane-models`: The `updated_at` and `created_at` fields in the `IntegrationSummary` struct are now optional (#171)
+- `fiberplane-api-client`: Pagination has been removed from the integrations listing endpoint (#171)
 
 ## [v1.0.0-beta.9] - 2024-02-05
 

--- a/fiberplane-api-client/src/lib.rs
+++ b/fiberplane-api-client/src/lib.rs
@@ -628,18 +628,8 @@ pub async fn oid_connections_list(client: &ApiClient) -> Result<Vec<models::OidC
 }
 
 #[doc = r#"Get a list of all integrations and their status"#]
-pub async fn integrations_get(
-    client: &ApiClient,
-    page: Option<i32>,
-    limit: Option<i32>,
-) -> Result<Vec<models::IntegrationSummary>> {
+pub async fn integrations_get(client: &ApiClient) -> Result<Vec<models::IntegrationSummary>> {
     let mut builder = client.request(Method::GET, "/api/profile/integrations")?;
-    if let Some(page) = page {
-        builder = builder.query(&[("page", page)]);
-    }
-    if let Some(limit) = limit {
-        builder = builder.query(&[("limit", limit)]);
-    }
     let response = builder.send().await?.error_for_status()?.json().await?;
 
     Ok(response)

--- a/fiberplane-models/src/integrations.rs
+++ b/fiberplane-models/src/integrations.rs
@@ -17,10 +17,12 @@ pub struct IntegrationSummary {
     pub id: IntegrationId,
     pub status: IntegrationStatus,
 
-    #[builder(setter(into))]
-    pub created_at: Timestamp,
-    #[builder(setter(into))]
-    pub updated_at: Timestamp,
+    #[builder(default, setter(into))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<Timestamp>,
+    #[builder(default, setter(into))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<Timestamp>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize, Display, EnumIter)]

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2443,8 +2443,6 @@ components:
       required:
         - id
         - status
-        - created_at
-        - updated_at
       properties:
         id:
           type: string
@@ -3504,9 +3502,6 @@ paths:
       description: "Get a list of all integrations and their status"
       tags:
         - Integrations
-      parameters:
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/limit"
       responses:
         "200":
           description: OK


### PR DESCRIPTION
# Description

the integrations list endpoint should return ALL integrations so pagination isnt really useful

accompanied by
- https://github.com/fiberplane/monofiber/pull/268
- https://github.com/fiberplane/fp/pull/275

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] ~~The changes have been tested to be backwards compatible.~~ they are not
- [x] The OpenAPI schema and generated client have been updated.
- [x] ~~New models module has been added to api generator xtask~~
- [x] ~~New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
