### PR TITLE
`@fiberplane/hooks`: Add fixes to `features` & `useLocalStorage`

### DIFF
--- a/fiberplane-hooks/package.json
+++ b/fiberplane-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiberplane/hooks",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Hooks for Fiberplane",
   "author": "Fiberplane <info@fiberplane.com>",
   "license": "MIT OR Apache-2.0",

--- a/fiberplane-hooks/src/features.ts
+++ b/fiberplane-hooks/src/features.ts
@@ -22,25 +22,24 @@ import { useLocalStorage } from "./useLocalStorage";
  * // src/hooks/features.ts
  * import { getFeatureHooks } from "@fiberplane/hooks";
  *
+ * const FEATURES = ["experimental-nav", "unstable-feature"] as const;
+ *
  * export const {
- *   features,
  *   useFeature,
  *   useFeatures,
  *   useFeaturesFromSearchParams,
- * } = getFeatureHooks(["experimental-nav", "unstable-feature"]);
+ * } = getFeatureHooks(FEATURES);
  *
- * export type Feature = (typeof features)[number];
+ * export type Feature = (typeof FEATURES)[number];
  *
  * export function isFeature(feature: string): feature is Feature {
- *   return feature === "experimental-nav" || feature === "unstable-feature";
+ *   return FEATURES.includes(feature as Feature);
  * }
  */
-export function getFeatureHooks<const F extends string>(
-  FEATURES: Array<F>,
+export function getFeatureHooks<const Feature extends string>(
+  FEATURES: ReadonlyArray<Feature>,
   FEATURES_KEY = "features",
 ) {
-  type Feature = typeof FEATURES[number];
-
   function isFeature(feature: string): feature is Feature {
     return FEATURES.includes(feature as Feature);
   }

--- a/fiberplane-hooks/src/useLocalStorage.ts
+++ b/fiberplane-hooks/src/useLocalStorage.ts
@@ -107,12 +107,14 @@ class WrappedLocalStorage extends EventEmitter {
   constructor() {
     super();
 
-    window.addEventListener("storage", (event) => {
-      if (!event.key) {
-        return;
-      }
-      this.emit(event.key, event.newValue);
-    });
+    if (typeof window !== "undefined") {
+      window.addEventListener("storage", (event) => {
+        if (!event.key) {
+          return;
+        }
+        this.emit(event.key, event.newValue);
+      });
+    }
   }
 
   getItem(key: string) {


### PR DESCRIPTION
# Description

As we had some tests failing that didn't have `window` available, `useLocalStorage` now has a small fix that catches that.

The `getFeatureHooks` function has improved typing now and allows for `as const` arrays to be passed in:

```ts
import { getFeatureHooks } from "@fiberplane/hooks";

const FEATURES = ["feature1", "feature2"] as const;

export const { useFeature, useFeatures, useFeaturesFromSearchParams } =
  getFeatureHooks(FEATURES);
```

Fixes FP-(issue)

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
~~- [ ] The OpenAPI schema and generated client have been updated.~~
~~- [ ] New models module has been added to api generator xtask~~
~~- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
~~- [ ] The CHANGELOG is updated.~~

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

