### PR TITLE
`@fiberplane/hooks`: Add fix for temporary `useValidStoredFeatures` hook

### DIFF
--- a/fiberplane-hooks/src/features.ts
+++ b/fiberplane-hooks/src/features.ts
@@ -186,6 +186,10 @@ export function getFeatureHooks<const Feature extends string>(
       });
     }
 
+    if (!features) {
+      return [initialFeatures, setFeatures] as const;
+    }
+
     return [features, setFeatures] as const;
   }
 


### PR DESCRIPTION
# Description

Fixes failing tests due to the async nature of `React.setState()`. It's a bit of a simple patch - but the hook is not here to stay and will be phased out in the next product release.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
~~- [ ] The OpenAPI schema and generated client have been updated.~~
~~- [ ] New models module has been added to api generator xtask~~
~~- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
~~- [ ] The CHANGELOG is updated.~~

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->
