### PR TITLE
`@fiberplane/hooks`: Simplify & fix `useLocalStorage`

### DIFF
--- a/fiberplane-hooks/package.json
+++ b/fiberplane-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiberplane/hooks",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Hooks for Fiberplane",
   "author": "Fiberplane <info@fiberplane.com>",
   "license": "MIT OR Apache-2.0",

--- a/fiberplane-hooks/package.json
+++ b/fiberplane-hooks/package.json
@@ -24,9 +24,6 @@
     "rollup-plugin-swc3": "^0.10.3",
     "typescript": "^5.2.2"
   },
-  "dependencies": {
-    "eventemitter3": "^5.0.1"
-  },
   "scripts": {
     "build": "rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
     "watch": "yarn build --watch",

--- a/fiberplane-hooks/src/useLocalStorage.ts
+++ b/fiberplane-hooks/src/useLocalStorage.ts
@@ -14,6 +14,7 @@ const IS_SERVER = typeof window === "undefined";
  * Hook that returns a value from `localStorage` and a setter for changing it.
  * The hook requires a `key` to identify the value in `localStorage` and a
  * `defaultValue` to return if the value is not found in `localStorage`.
+ * The watches the value stored in `localStorage` and returns the updated value.
  */
 export function useLocalStorage<T>(key: string, defaultValue: T) {
   const getCurrentValue = useHandler(() => {

--- a/fiberplane-hooks/src/useLocalStorage.ts
+++ b/fiberplane-hooks/src/useLocalStorage.ts
@@ -1,154 +1,85 @@
-import { EventEmitter } from "eventemitter3";
 import { useEffect, useState } from "react";
 
 import { useHandler } from "./useHandler";
 
-type JsonPrimitive = string | number | boolean | null;
+declare global {
+  interface WindowEventMap {
+    "local-storage": StorageEvent;
+  }
+}
 
-type JsonObject = { [key: string]: JsonValue };
-
-type JsonArray = Array<JsonValue>;
-
-type JsonValue = JsonPrimitive | JsonArray | JsonObject;
+const IS_SERVER = typeof window === "undefined";
 
 /**
- * Hook that returns the current value of a localStorage key and a setter for
- * that value. It also listens for changes to the localStorage key and updates
- * the value accordingly.
- *
- * If the setter is called with `null`, the key will be removed from
- * localStorage and the default value will be used instead.
- *
- * @param key The localStorage key
- * @param defaultValue The default value to use if the key doesn't exist
- * @returns A tuple containing the current value and a setter for that value
- *
- * @example
- * const [value, setValue] = useLocalStorage("my_key", "my_default_value");
- *
- * // If the key "my_key" doesn't exist in localStorage, value will be set to "my_default_value"
- * setValue("my_new_value");
- * // If later the updated value is logged
- * console.log(value); // "my_new_value"
- * // If the setter is called with null the value in localStorage will be removed
- * // and the default value will be used
- * setValue(null); // Removes the key from localStorage (causing value to be)
- * // Logging the updated value would result in the default value being used (not null)
- * console.log(value); // "my_default_value"
+ * Hook that returns a value from `localStorage` and a setter for changing it.
+ * The hook requires a `key` to identify the value in `localStorage` and a
+ * `defaultValue` to return if the value is not found in `localStorage`.
  */
-export function useLocalStorage<T extends JsonValue>(
-  key: string,
-  defaultValue: T,
-): readonly [T, (value: T | null) => void] {
-  const [value, internalSetValue] = useState(() => {
-    const storedValue = localStorage.getItem(key);
-    if (storedValue === null) {
+export function useLocalStorage<T>(key: string, defaultValue: T) {
+  const getCurrentValue = useHandler(() => {
+    if (IS_SERVER) {
       return defaultValue;
     }
 
-    const parsedValue = safeJSONParse(storedValue);
+    try {
+      const rawValue = window.localStorage.getItem(key);
+      if (rawValue === null) {
+        return defaultValue;
+      }
 
-    if (parsedValue === null) {
+      const parsedValue: T = JSON.parse(rawValue);
+      return parsedValue;
+    } catch (error) {
+      console.error("Error reading from localStorage", error);
       return defaultValue;
     }
-
-    return parsedValue;
   });
 
-  const handleChange = useHandler((event: StorageEvent) => {
-    if (event.key === key) {
-      internalSetValue(event.newValue ? JSON.parse(event.newValue) : undefined);
-    }
-  });
+  const [storedValue, setStoredValue] = useState<T>(getCurrentValue);
 
-  const handleLocalChange = useHandler(
-    (event: { key: string; newValue: T | undefined }) => {
-      // If the key is different or the value is the same, do nothing
-      if (event.key !== key || event.newValue === value) {
+  /**
+   * A setter function that writes the new value to `localStorage` and updates
+   * the state.
+   */
+  const setValue: React.Dispatch<React.SetStateAction<T>> = useHandler(
+    (value) => {
+      if (IS_SERVER) {
         return;
       }
 
-      // If the value is nul
-      if (event.newValue === null && value !== defaultValue) {
-        internalSetValue(defaultValue);
-        return;
-      }
+      try {
+        const newValue = JSON.stringify(value);
+        window.localStorage.setItem(key, newValue);
+        setStoredValue(value);
 
-      internalSetValue(event.newValue);
+        // As the `storage` event handler is not triggered by the same window
+        // that triggered the change, we need to manually dispatch the event.
+        const storageEvent = new StorageEvent("local-storage", { key });
+        window.dispatchEvent(storageEvent);
+      } catch (error) {
+        console.error("Error writing to localStorage", error);
+      }
     },
   );
 
-  useEffect(() => {
-    window.addEventListener("storage", handleChange);
-    wrappedLocalStorage.addListener("local_storage", handleLocalChange);
-
-    return () => {
-      window.removeEventListener("storage", handleChange);
-      wrappedLocalStorage.removeListener("local_storage", handleLocalChange);
-    };
-  }, [handleChange, handleLocalChange]);
-
-  // Passing in null will result the value to the initial value
-  const setValue = useHandler((value: T | null) => {
-    const newValue = value ?? defaultValue;
-    internalSetValue(newValue);
-    if (value === null) {
-      wrappedLocalStorage.removeItem(key);
+  const handleStorageChange = useHandler((event: StorageEvent) => {
+    if (event.key !== key) {
       return;
     }
 
-    wrappedLocalStorage.setItem(key, newValue);
+    const currentValue = getCurrentValue();
+    setStoredValue(currentValue);
   });
 
-  return [value, setValue] as const;
-}
+  useEffect(() => {
+    window.addEventListener("storage", handleStorageChange);
+    window.addEventListener("local-storage", handleStorageChange);
 
-class WrappedLocalStorage extends EventEmitter {
-  constructor() {
-    super();
+    return () => {
+      window.removeEventListener("storage", handleStorageChange);
+      window.removeEventListener("local-storage", handleStorageChange);
+    };
+  }, [handleStorageChange]);
 
-    if (typeof window !== "undefined") {
-      window.addEventListener("storage", (event) => {
-        if (!event.key) {
-          return;
-        }
-        this.emit(event.key, event.newValue);
-      });
-    }
-  }
-
-  getItem(key: string) {
-    const value = localStorage.getItem(key);
-
-    if (value === null) {
-      return null;
-    }
-
-    return safeJSONParse(value);
-  }
-
-  setItem(key: string, value: JsonValue) {
-    const serializedValue = JSON.stringify(value);
-    localStorage.setItem(key, serializedValue);
-    this.emit("local_storage", { key, newValue: value });
-  }
-
-  removeItem(key: string) {
-    localStorage.removeItem(key);
-    this.emit("local_storage", { key, newValue: null });
-  }
-}
-
-const wrappedLocalStorage = new WrappedLocalStorage();
-
-function safeJSONParse(value: string | null) {
-  try {
-    if (value === null) {
-      return;
-    }
-    return JSON.parse(value);
-  } catch (error) {
-    console.warn("Error parsing json from localStorage", error);
-    return null;
-  }
+  return [storedValue, setValue] as const;
 }


### PR DESCRIPTION
# Description

Reduces complexity of `useLocalStorage` and get rid of the package's `eventemitter3` dependency.
The local storage hook won't set any values that aren't passed in by the user (like `null`) and uses a custom `StorageEvent` to update the active tab.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
~~- [ ] The OpenAPI schema and generated client have been updated.~~
~~- [ ] New models module has been added to api generator xtask~~
~~- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
~~- [ ] The CHANGELOG is updated.~~

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

