### PR TITLE
`@fiberplane/hooks`: Add empty fallback array for e2e test

### DIFF
--- a/fiberplane-hooks/src/features.ts
+++ b/fiberplane-hooks/src/features.ts
@@ -94,7 +94,10 @@ export function getFeatureHooks<const Feature extends string>(
       useValidStoredFeatures();
 
     const isFeatureEnabled = useMemo(() => {
-      const storedFeature = features.find(({ name }) => name === feature);
+      // Empty fallback array for failing e2e tests that set feature flags
+      const storedFeature = (features || []).find(
+        ({ name }) => name === feature,
+      );
       if (!storedFeature) {
         return false;
       }

--- a/fiberplane-hooks/src/features.ts
+++ b/fiberplane-hooks/src/features.ts
@@ -94,10 +94,8 @@ export function getFeatureHooks<const Feature extends string>(
       useValidStoredFeatures();
 
     const isFeatureEnabled = useMemo(() => {
-      // Empty fallback array for failing e2e tests that set feature flags
-      const storedFeature = (features || []).find(
-        ({ name }) => name === feature,
-      );
+      // Conditional fallback array for failing e2e tests that set feature flags
+      const storedFeature = features?.find(({ name }) => name === feature);
       if (!storedFeature) {
         return false;
       }
@@ -141,9 +139,9 @@ export function getFeatureHooks<const Feature extends string>(
     const validFeatures = new Set(parameterFeatures.filter(isFeature));
 
     // As the localStorage features aren't updated immediately on initial load,
-    // we use an empty array as a fallback. We can remove this fallback once we
-    // get rid of the temporary hook below.
-    const updatedFeatures = (validStoredFeatures || []).map((storedFeature) => {
+    // we use a conditional check. We can remove this fallback once we get rid
+    // of the temporary hook below.
+    const updatedFeatures = validStoredFeatures?.map((storedFeature) => {
       if (validFeatures.has(storedFeature.name)) {
         return {
           ...storedFeature,


### PR DESCRIPTION
# Description

Another microfix for failing tests. Will be fixed once we're phasing out the older features logic.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

~~- [ ] The changes have been tested to be backwards compatible.~~
~~- [ ] The OpenAPI schema and generated client have been updated.~~
~~- [ ] New models module has been added to api generator xtask~~
~~- [ ] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
~~- [ ] The CHANGELOG is updated.~~

