### PR TITLE
Bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ major version hasn't changed.
 
 TBD
 
-## [v1.0.0-beta.12] - 2024-02-26
+## [v1.0.0-beta.12] - 2024-02-23
 
 - `API` schema: Add routes to manipulate the front matter collections in a workspace (a saved front matter
   schema with an attached name).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -29,15 +29,15 @@ base64uuid = { version = "1.1.0", path = "base64uuid", default-features = false 
 bytes = { version = "1", features = ["serde"] }
 fp-bindgen = { version = "3.0.0" }
 fp-bindgen-support = { version = "3.0.0" }
-fiberplane = { version = "1.0.0-beta.11", path = "fiberplane" }
-fiberplane-api-client = { version = "1.0.0-beta.11", path = "fiberplane-api-client" }
+fiberplane = { version = "1.0.0-beta.12", path = "fiberplane" }
+fiberplane-api-client = { version = "1.0.0-beta.12", path = "fiberplane-api-client" }
 fiberplane-ci = { version = "0.1.0", path = "fiberplane-ci" }
-fiberplane-markdown = { version = "1.0.0-beta.11", path = "fiberplane-markdown" }
-fiberplane-models = { version = "1.0.0-beta.11", path = "fiberplane-models" }
+fiberplane-markdown = { version = "1.0.0-beta.12", path = "fiberplane-markdown" }
+fiberplane-models = { version = "1.0.0-beta.12", path = "fiberplane-models" }
 fiberplane-openapi-rust-gen = { version = "0.1.0", path = "fiberplane-openapi-rust-gen" }
-fiberplane-provider-bindings = { version = "2.0.0-beta.11", path = "fiberplane-provider-protocol/fiberplane-provider-bindings" }
-fiberplane-provider-runtime = { version = "2.0.0-beta.11", path = "fiberplane-provider-protocol/fiberplane-provider-runtime" }
-fiberplane-templates = { version = "1.0.0-beta.11", path = "fiberplane-templates" }
+fiberplane-provider-bindings = { version = "2.0.0-beta.12", path = "fiberplane-provider-protocol/fiberplane-provider-bindings" }
+fiberplane-provider-runtime = { version = "2.0.0-beta.12", path = "fiberplane-provider-protocol/fiberplane-provider-runtime" }
+fiberplane-templates = { version = "1.0.0-beta.12", path = "fiberplane-templates" }
 insta = { version = "1.31.0" }
 once_cell = { version = "1.12" }
 serde = { version = "1", features = ["derive"] }

--- a/fiberplane-markdown/Cargo.toml
+++ b/fiberplane-markdown/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 
 [dependencies]
 fiberplane-models = { workspace = true }

--- a/fiberplane-models/Cargo.toml
+++ b/fiberplane-models/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 
 [lib]
 crate-type = ["lib"]

--- a/fiberplane-provider-protocol/fiberplane-provider-bindings/Cargo.toml
+++ b/fiberplane-provider-protocol/fiberplane-provider-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiberplane-provider-bindings"
-version = "2.0.0-beta.11"
+version = "2.0.0-beta.12"
 authors = { workspace = true }
 edition = "2018"
 description = "Fiberplane Provider protocol bindings"

--- a/fiberplane-provider-protocol/fiberplane-provider-runtime/Cargo.toml
+++ b/fiberplane-provider-protocol/fiberplane-provider-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fiberplane-provider-runtime"
 description = "Wasmer runtime for Fiberplane Providers"
 readme = "README.md"
-version = "2.0.0-beta.11"
+version = "2.0.0-beta.12"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }

--- a/fiberplane-templates/Cargo.toml
+++ b/fiberplane-templates/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 
 [features]
 default = ["convert", "expand", "examples"]

--- a/fiberplane/Cargo.toml
+++ b/fiberplane/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.11"
+version = "1.0.0-beta.12"
 
 [lib]
 crate-type = ["lib"]

--- a/mondrian-charts/Cargo.toml
+++ b/mondrian-charts/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 keywords = ["chart", "charts", "metrics", "prometheus", "opentelemetry"]
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "0.9.0"
+version = "0.10.0"
 
 [features]
 default = ["fiberplane", "image"]


### PR DESCRIPTION
This PR bumps the version numbers so they match the next release.
Please verify the version numbers are correct, and update the CHANGELOG manually. You
should merge this PR ASAP, but no later than before the next release cycle starts.

# Checklist

- [x] Version numbers are correct
- [x] `CHANGELOG.md` has been updated