### PR TITLE
Bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ major version hasn't changed.
 
 ## unreleased
 
+## [v1.0.0-beta.14] - 2024-03-07
+
+- Update dependencies
+
 ## [v1.0.0-beta.13] - 2024-03-01
 
 - Update dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ base64uuid = { version = "1.1.0", path = "base64uuid", default-features = false 
 bytes = { version = "1", features = ["serde"] }
 fp-bindgen = { version = "3.0.0" }
 fp-bindgen-support = { version = "3.0.0" }
-fiberplane = { version = "1.0.0-beta.13", path = "fiberplane" }
+fiberplane = { version = "1.0.0-beta.14", path = "fiberplane" }
 fiberplane-api-client = { version = "1.0.0-beta.13", path = "fiberplane-api-client" }
 fiberplane-ci = { version = "0.1.0", path = "fiberplane-ci" }
 fiberplane-markdown = { version = "1.0.0-beta.13", path = "fiberplane-markdown" }
@@ -37,7 +37,7 @@ fiberplane-models = { version = "1.0.0-beta.13", path = "fiberplane-models" }
 fiberplane-openapi-rust-gen = { version = "0.1.0", path = "fiberplane-openapi-rust-gen" }
 fiberplane-provider-bindings = { version = "2.0.0-beta.13", path = "fiberplane-provider-protocol/fiberplane-provider-bindings" }
 fiberplane-provider-runtime = { version = "2.0.0-beta.13", path = "fiberplane-provider-protocol/fiberplane-provider-runtime" }
-fiberplane-templates = { version = "1.0.0-beta.13", path = "fiberplane-templates" }
+fiberplane-templates = { version = "1.0.0-beta.14", path = "fiberplane-templates" }
 insta = { version = "1.31.0" }
 once_cell = { version = "1.12" }
 serde = { version = "1", features = ["derive"] }

--- a/fiberplane-templates/Cargo.toml
+++ b/fiberplane-templates/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.13"
+version = "1.0.0-beta.14"
 
 [features]
 default = ["convert", "expand", "examples"]

--- a/fiberplane/Cargo.toml
+++ b/fiberplane/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "1.0.0-beta.13"
+version = "1.0.0-beta.14"
 
 [lib]
 crate-type = ["lib"]

--- a/mondrian-charts/Cargo.toml
+++ b/mondrian-charts/Cargo.toml
@@ -8,7 +8,7 @@ license = { workspace = true }
 keywords = ["chart", "charts", "metrics", "prometheus", "opentelemetry"]
 repository = { workspace = true }
 rust-version = { workspace = true }
-version = "0.11.0"
+version = "0.12.0"
 
 [features]
 default = ["fiberplane", "image"]


### PR DESCRIPTION
This PR bumps the version numbers so they match the next release.
Please verify the version numbers are correct, and update the CHANGELOG manually. You
should merge this PR ASAP, but no later than before the next release cycle starts.

# Checklist

- [x] Version numbers are correct
- [x] `CHANGELOG.md` has been updated