### PR TITLE
Allow configuration of default number of xticks and yticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ major version hasn't changed.
 
 ## unreleased
 
+- `fiberplane-charts`: Add configuration to MetricsChart for number of ticks you'd prefer to see on an axis (defaults to previously hard-coded values)
 - `fiberplane-models`: Add extra types to front matter values, and add a value validation method to
   front matter schema entries.
 - `fiberplane-models`: The `updated_at` and `created_at` fields in the `IntegrationSummary` struct are now optional (#171)

--- a/fiberplane-charts/src/CoreChart/CoreChart.tsx
+++ b/fiberplane-charts/src/CoreChart/CoreChart.tsx
@@ -23,6 +23,8 @@ export function CoreChart<S, P>({
   shapeStrokeWidth = 1,
   showTooltip,
   timeRange,
+  numXTicks = 12,
+  numYTicks = 8,
   ...props
 }: CoreChartProps<S, P>): JSX.Element {
   const interactiveControls = useInteractiveControls(readOnly);
@@ -111,6 +113,8 @@ export function CoreChart<S, P>({
         <GridWithAxes
           {...props}
           chart={chart}
+          numXTicks={numXTicks}
+          numYTicks={numYTicks}
           scales={scales}
           tickFormatters={tickFormatters}
         />

--- a/fiberplane-charts/src/CoreChart/GridWithAxes/GridWithAxes.tsx
+++ b/fiberplane-charts/src/CoreChart/GridWithAxes/GridWithAxes.tsx
@@ -27,6 +27,8 @@ type Props = {
   scales: Scales;
   shouldAnimateYScale?: boolean;
   tickFormatters: TickFormatters;
+  numXTicks: number;
+  numYTicks: number;
 };
 
 export const GridWithAxes = memo(function GridWithAxes({
@@ -35,6 +37,8 @@ export const GridWithAxes = memo(function GridWithAxes({
   gridRowsShown = true,
   axisLinesShown = true,
   gridDasharray,
+  numXTicks, // NOTE - default should be set in CoreChart
+  numYTicks, // NOTE - default should be set in CoreChart
   scales,
   shouldAnimateYScale,
   tickFormatters,
@@ -53,12 +57,12 @@ export const GridWithAxes = memo(function GridWithAxes({
   );
 
   const xTicks = useMemo(
-    () => getTicks(xAxis, xMax, xScale, 12, getMaxXTickValue),
-    [xAxis, xMax, xScale],
+    () => getTicks(xAxis, xMax, xScale, numXTicks, getMaxXTickValue),
+    [xAxis, xMax, xScale, numXTicks],
   );
   const yTicks = useMemo(
-    () => getTicks(yAxis, yMax, animatedScale, 8, getMaxYTickValue),
-    [yAxis, yMax, animatedScale],
+    () => getTicks(yAxis, yMax, animatedScale, numYTicks, getMaxYTickValue),
+    [yAxis, yMax, animatedScale, numYTicks],
   );
 
   return (

--- a/fiberplane-charts/src/CoreChart/GridWithAxes/GridWithAxes.tsx
+++ b/fiberplane-charts/src/CoreChart/GridWithAxes/GridWithAxes.tsx
@@ -131,6 +131,11 @@ export function getTicks(
   numTicks: number,
   getMaxAllowedTick: (ticks: Array<number>, maxValue: number) => number,
 ): Array<number> {
+  // If we only want two ticks, just render the min and max
+  if (numTicks === 2) {
+    console.log("getTicks: numTicks === 2");
+    return [axis.minValue, axis.maxValue];
+  }
   const suggestions = axis.tickSuggestions;
   const { ticks, interval } = suggestions
     ? getTicksAndIntervalFromSuggestions(axis, suggestions, numTicks)

--- a/fiberplane-charts/src/CoreChart/GridWithAxes/GridWithAxes.tsx
+++ b/fiberplane-charts/src/CoreChart/GridWithAxes/GridWithAxes.tsx
@@ -133,7 +133,6 @@ export function getTicks(
 ): Array<number> {
   // If we only want two ticks, just render the min and max
   if (numTicks === 2) {
-    console.log("getTicks: numTicks === 2");
     return [axis.minValue, axis.maxValue];
   }
   const suggestions = axis.tickSuggestions;

--- a/fiberplane-charts/src/CoreChart/types.ts
+++ b/fiberplane-charts/src/CoreChart/types.ts
@@ -57,6 +57,16 @@ export type CoreChartProps<S, P> = {
   gridStrokeColor?: string;
 
   /**
+   * Override the suggested number of ticks along the X axis. (default: 12)
+   */
+  numXTicks?: number;
+
+  /**
+   * Override the suggested number of ticks along the Y axis. (default: 8)
+   */
+  numYTicks?: number;
+
+  /**
    * Handler that is invoked when the time range is changed.
    *
    * If no handler is specified, no UI for changing the time range is


### PR DESCRIPTION
# Description

Sometimes we want to give a hint to the chart regarding how many ticks it should use on the axes. 

This PR allows you to set these as props on `MetricsChart`, while falling back to the hard coded values we're currently using.

Additionally, if you only specify 2 ticks, it assumes you just want to see the max and min. Unfortunately, this doesn't work too well for the Y-axis, and for the X-axis, your rightmost tick label will probably get cut off for timestamps. However, it's better than specifying two ticks and only having one at the origin and one in the middle.

Fixes FP-3595

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
