### PR TITLE
Use --color-input-border-default variable since design token was updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ major version hasn't changed.
 
 ## unreleased
 
+- `fiberplane-ui`: Fix input border colors in dark mode (use `--color-input-border-default` instead of `--color-input-border`)
 - `fiberplane-charts`: Add configuration to MetricsChart for number of ticks you'd prefer to see on an axis (defaults to previously hard-coded values)
 - `fiberplane-models`: Add extra types to front matter values, and add a value validation method to
   front matter schema entries.

--- a/fiberplane-ui/src/components/Input/TextInput.ts
+++ b/fiberplane-ui/src/components/Input/TextInput.ts
@@ -2,7 +2,7 @@ import { styled } from "styled-components";
 
 export const TextInput = styled.input`
   background-color: var(--color-input-bg, #fff);
-  border: 1px solid var(--color-input-border, #d6d4d9);
+  border: 1px solid var(--color-input-border-default, #d6d4d9);
   border-radius: var(--radius-default, 10px);
   color: var(--color-input-fg-input, #000);
   padding: 6px 12px;


### PR DESCRIPTION
# Description

The variable name changed from `--color-input-border` to `--color-input-border-default` and we need to update things to reflect that!

Fixes FP-3617

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:
