### PR TITLE
add models for github pull request front matter

### DIFF
--- a/fiberplane-models/src/front_matter_schemas.rs
+++ b/fiberplane-models/src/front_matter_schemas.rs
@@ -1,3 +1,4 @@
+use crate::notebooks::front_matter::FrontMatterGitHubPullRequest;
 use crate::notebooks::{
     front_matter::{
         FrontMatterDateTimeValue, FrontMatterNumberValue, FrontMatterPagerDutyIncident,
@@ -130,6 +131,9 @@ pub enum FrontMatterValueSchema {
 
     #[serde(rename = "pagerduty_incident")]
     PagerDutyIncident(FrontMatterPagerDutyIncidentSchema),
+
+    #[serde(rename = "github_pull_request")]
+    GitHubPullRequest(FrontMatterGitHubPullRequestSchema),
 }
 
 impl FrontMatterValueSchema {
@@ -143,6 +147,7 @@ impl FrontMatterValueSchema {
             FrontMatterValueSchema::DateTime(schema) => schema.validate_value(value),
             FrontMatterValueSchema::User(schema) => schema.validate_value(value),
             FrontMatterValueSchema::PagerDutyIncident(schema) => schema.validate_value(value),
+            FrontMatterValueSchema::GitHubPullRequest(schema) => schema.validate_value(value),
         }
     }
 
@@ -156,6 +161,9 @@ impl FrontMatterValueSchema {
             FrontMatterValueSchema::DateTime(schema) => schema.validate_front_matter_value(value),
             FrontMatterValueSchema::User(schema) => schema.validate_front_matter_value(value),
             FrontMatterValueSchema::PagerDutyIncident(schema) => {
+                schema.validate_front_matter_value(value)
+            }
+            FrontMatterValueSchema::GitHubPullRequest(schema) => {
                 schema.validate_front_matter_value(value)
             }
         }
@@ -552,5 +560,50 @@ impl FrontMatterPagerDutyIncidentSchema {
 impl From<FrontMatterPagerDutyIncidentSchema> for FrontMatterValueSchema {
     fn from(v: FrontMatterPagerDutyIncidentSchema) -> Self {
         Self::PagerDutyIncident(v)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
+#[cfg_attr(
+    feature = "fp-bindgen",
+    derive(Serializable),
+    fp(rust_module = "fiberplane_models::front_matter_schemas")
+)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct FrontMatterGitHubPullRequestSchema {
+    #[builder(default, setter(into))]
+    pub display_name: String,
+
+    #[builder(default, setter(into, strip_option))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_name: Option<String>,
+}
+
+impl FrontMatterGitHubPullRequestSchema {
+    pub fn validate_value(
+        &self,
+        value: Value,
+    ) -> Result<FrontMatterValue, FrontMatterValidationError> {
+        Ok(FrontMatterGitHubPullRequest::try_from(value)?.into())
+    }
+
+    pub fn validate_front_matter_value(
+        &self,
+        value: &FrontMatterValue,
+    ) -> Result<(), FrontMatterValidationError> {
+        match value {
+            FrontMatterValue::GitHubPullRequest(_) => Ok(()),
+            other => Err(FrontMatterValidationError::wrong_variant(
+                other.get_type(),
+                "github_pull_request",
+            )),
+        }
+    }
+}
+
+impl From<FrontMatterGitHubPullRequestSchema> for FrontMatterValueSchema {
+    fn from(v: FrontMatterGitHubPullRequestSchema) -> Self {
+        Self::GitHubPullRequest(v)
     }
 }

--- a/fiberplane-models/src/integrations.rs
+++ b/fiberplane-models/src/integrations.rs
@@ -424,3 +424,84 @@ impl axum_07::response::IntoResponse for GitHubAppWebhookError {
         (status_code, body).into_response()
     }
 }
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
+#[cfg_attr(
+    feature = "fp-bindgen",
+    derive(Serializable),
+    fp(rust_module = "fiberplane_models::integrations")
+)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct GitHubAppAddPullRequest {
+    /// The url of the GitHub pull request
+    pub url: String,
+}
+
+#[derive(Serialize, Debug, Error)]
+#[serde(tag = "error", content = "details", rename_all = "snake_case")]
+pub enum GitHubAppAddPullRequestError {
+    #[error("access denied to repository")]
+    AccessDenied,
+
+    #[error("provided url is invalid")]
+    InvalidUrl,
+
+    #[error("integration not installed")]
+    IntegrationNotInstalled,
+
+    #[error("refresh token expired, please re-link integration")]
+    RefreshTokenExpired,
+
+    #[error("didnt receive new refresh token from GitHub")]
+    RefreshTokenNotReceived,
+
+    #[error("unknown error occurred")]
+    InternalServerError,
+
+    #[error(transparent)]
+    Auth(AuthError),
+}
+
+impl GitHubAppAddPullRequestError {
+    #[cfg(any(feature = "axum_06", feature = "axum_07"))]
+    fn status_code(&self) -> StatusCode {
+        match self {
+            GitHubAppAddPullRequestError::AccessDenied => StatusCode::UNAUTHORIZED,
+            GitHubAppAddPullRequestError::InvalidUrl => StatusCode::BAD_REQUEST,
+            GitHubAppAddPullRequestError::IntegrationNotInstalled => {
+                StatusCode::PRECONDITION_FAILED
+            }
+            GitHubAppAddPullRequestError::RefreshTokenExpired => StatusCode::GONE,
+            GitHubAppAddPullRequestError::RefreshTokenNotReceived => StatusCode::BAD_GATEWAY,
+            GitHubAppAddPullRequestError::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
+            GitHubAppAddPullRequestError::Auth(auth) => auth.status_code(),
+        }
+    }
+}
+
+#[cfg(feature = "axum_06")]
+impl axum_06::response::IntoResponse for GitHubAppAddPullRequestError {
+    fn into_response(self) -> axum_06::response::Response {
+        let body = serde_json::to_string(&self).expect("unable to serialize error body");
+        let status_code = self.status_code();
+
+        (status_code, body).into_response()
+    }
+}
+
+#[cfg(feature = "axum_07")]
+impl axum_07::response::IntoResponse for GitHubAppAddPullRequestError {
+    fn into_response(self) -> axum_07::response::Response {
+        let body = serde_json::to_string(&self).expect("unable to serialize error body");
+        let status_code = self.status_code();
+
+        (status_code, body).into_response()
+    }
+}
+
+impl From<AuthError> for GitHubAppAddPullRequestError {
+    fn from(value: AuthError) -> Self {
+        GitHubAppAddPullRequestError::Auth(value)
+    }
+}

--- a/fiberplane-models/src/integrations.rs
+++ b/fiberplane-models/src/integrations.rs
@@ -367,8 +367,20 @@ pub enum GitHubAppWebhookError {
     #[error("failed to parse payload as JSON")]
     InvalidJson,
 
+    #[error("payload did not contain installation id")]
+    NoInstallation,
+
+    #[error("installation id is not registered with us")]
+    InstallationIdUnknown,
+
     #[error("invalid github app config")]
     InvalidConfig,
+
+    #[error("event header missing")]
+    EventMissing,
+
+    #[error("event header contains non ascii characters")]
+    EventInvalid,
 
     #[error("unknown error occurred")]
     InternalServerError,
@@ -383,7 +395,11 @@ impl GitHubAppWebhookError {
             GitHubAppWebhookError::SignatureAlgorithmUnsupported => StatusCode::BAD_REQUEST,
             GitHubAppWebhookError::SignatureMismatch => StatusCode::BAD_REQUEST,
             GitHubAppWebhookError::InvalidJson => StatusCode::BAD_REQUEST,
+            GitHubAppWebhookError::NoInstallation => StatusCode::BAD_REQUEST,
+            GitHubAppWebhookError::InstallationIdUnknown => StatusCode::NOT_FOUND,
             GitHubAppWebhookError::InvalidConfig => StatusCode::INTERNAL_SERVER_ERROR,
+            GitHubAppWebhookError::EventMissing => StatusCode::BAD_REQUEST,
+            GitHubAppWebhookError::EventInvalid => StatusCode::BAD_REQUEST,
             GitHubAppWebhookError::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/fiberplane-models/src/notebooks/front_matter.rs
+++ b/fiberplane-models/src/notebooks/front_matter.rs
@@ -662,15 +662,11 @@ impl TryFrom<serde_json::Value> for FrontMatterPagerDutyIncident {
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
 pub struct FrontMatterGitHubPullRequest {
-    /// HTML url of this GitHub pull request. This is the only required value when creating
-    /// this front matter schema. Every other field is marked as optional and will be automatically
-    /// populated by the backend whenever front matter values get updated or an incoming GitHub
-    /// webhook got handled.
+    /// HTML url of this GitHub pull request
     pub html_url: String,
 
     /// Global unique ID of the GitHub pull request. This gets used to find this very front matter
     /// within all notebooks whenever a webhook from GitHub gets handled. GitHub assigns this ID.
-    #[builder(setter())]
     pub id: u64,
 
     /// The owner of the repository where this pull request was created on
@@ -682,8 +678,7 @@ pub struct FrontMatterGitHubPullRequest {
     pub repo_name: String,
 
     /// The pull request number within this repository. Please note that GitHub
-    /// treats pull request and issue numbers as the same.
-    #[builder(setter())]
+    /// treats pull request and issue numbers as the same
     pub number: u64,
 
     /// Title of the pull request
@@ -695,7 +690,6 @@ pub struct FrontMatterGitHubPullRequest {
     pub branch: String,
 
     /// Amount of commits in this PR
-    #[builder(setter())]
     pub commits: u64,
 
     /// Creator of the pull request
@@ -715,11 +709,9 @@ pub struct FrontMatterGitHubPullRequest {
     pub assignee_avatar_url: Option<String>,
 
     /// Labels attached to this PR
-    #[builder(setter())]
     pub labels: Vec<String>,
 
     /// Reviewers requested for this PR
-    #[builder(setter())]
     pub reviewers: Vec<String>,
 
     /// State of the pull request
@@ -727,11 +719,9 @@ pub struct FrontMatterGitHubPullRequest {
     pub state: String,
 
     /// Whenever the pull request is a draft
-    #[builder(setter())]
     pub draft: bool,
 
     /// Whenever the pull request was merged
-    #[builder(setter())]
     pub merged: bool,
 
     /// Timestamp when this pull request was created
@@ -741,7 +731,7 @@ pub struct FrontMatterGitHubPullRequest {
     /// Timestamp of the last update received by Fiberplane to this pull request. May be outdated
     /// if there are changes that the GitHub webhook has not yet sent out
     #[builder(setter(into))]
-    pub last_updated: Timestamp,
+    pub updated_at: Timestamp,
 }
 
 impl From<FrontMatterGitHubPullRequest> for FrontMatterValue {

--- a/fiberplane-models/src/notebooks/front_matter.rs
+++ b/fiberplane-models/src/notebooks/front_matter.rs
@@ -690,13 +690,25 @@ pub struct FrontMatterGitHubPullRequest {
     #[builder(setter(into))]
     pub author: String,
 
+    /// GitHub Avatar URL of the author
+    #[builder(setter(into))]
+    pub author_avatar_url: String,
+
     /// Assignee of this pull request
     #[builder(setter(into))]
-    pub assignee: String,
+    pub assignee: Option<String>,
 
-    /// Current status of this pull request
+    /// State of the pull request
     #[builder(setter(into))]
-    pub status: String,
+    pub state: String,
+
+    /// Whenever the pull request is a draft
+    #[builder(setter())]
+    pub draft: bool,
+
+    /// Whenever the pull request was merged
+    #[builder(setter())]
+    pub merged: bool,
 
     /// Timestamp of the last update received by Fiberplane to this pull request. May be outdated
     /// if there are changes that the GitHub webhook has not yet sent out

--- a/fiberplane-models/src/notebooks/front_matter.rs
+++ b/fiberplane-models/src/notebooks/front_matter.rs
@@ -57,7 +57,6 @@ pub type FrontMatter = BTreeMap<String, FrontMatterValue>;
 )]
 #[non_exhaustive]
 #[serde(untagged)]
-#[allow(clippy::large_enum_variant)]
 pub enum FrontMatterValue {
     /// A timestamp front matter value
     DateTime(FrontMatterDateTimeValue),
@@ -85,7 +84,7 @@ pub enum FrontMatterValue {
 
     /// A GitHub pull request front matter value
     #[serde(rename = "github_pull_request")]
-    GitHubPullRequest(FrontMatterGitHubPullRequest),
+    GitHubPullRequest(Box<FrontMatterGitHubPullRequest>),
 }
 
 /// Error from validating a JSON object as a correct front matter value
@@ -747,7 +746,7 @@ pub struct FrontMatterGitHubPullRequest {
 
 impl From<FrontMatterGitHubPullRequest> for FrontMatterValue {
     fn from(v: FrontMatterGitHubPullRequest) -> Self {
-        Self::GitHubPullRequest(v)
+        Self::GitHubPullRequest(Box::new(v))
     }
 }
 

--- a/fiberplane-models/src/notebooks/front_matter.rs
+++ b/fiberplane-models/src/notebooks/front_matter.rs
@@ -686,6 +686,18 @@ pub struct FrontMatterGitHubPullRequest {
     #[builder(setter())]
     pub number: u64,
 
+    /// Title of the pull request
+    #[builder(setter(into))]
+    pub title: String,
+
+    /// Branch name of this PR
+    #[builder(setter(into))]
+    pub branch: String,
+
+    /// Amount of commits in this PR
+    #[builder(setter())]
+    pub commits: u64,
+
     /// Creator of the pull request
     #[builder(setter(into))]
     pub author: String,
@@ -698,6 +710,18 @@ pub struct FrontMatterGitHubPullRequest {
     #[builder(setter(into))]
     pub assignee: Option<String>,
 
+    /// GitHub avatar URL of the assignee
+    #[builder(setter(into))]
+    pub assignee_avatar_url: Option<String>,
+
+    /// Labels attached to this PR
+    #[builder(setter())]
+    pub labels: Vec<String>,
+
+    /// Reviewers requested for this PR
+    #[builder(setter())]
+    pub reviewers: Vec<String>,
+
     /// State of the pull request
     #[builder(setter(into))]
     pub state: String,
@@ -709,6 +733,10 @@ pub struct FrontMatterGitHubPullRequest {
     /// Whenever the pull request was merged
     #[builder(setter())]
     pub merged: bool,
+
+    /// Timestamp when this pull request was created
+    #[builder(setter(into))]
+    pub created_at: Timestamp,
 
     /// Timestamp of the last update received by Fiberplane to this pull request. May be outdated
     /// if there are changes that the GitHub webhook has not yet sent out

--- a/fiberplane-models/src/notebooks/front_matter.rs
+++ b/fiberplane-models/src/notebooks/front_matter.rs
@@ -57,6 +57,7 @@ pub type FrontMatter = BTreeMap<String, FrontMatterValue>;
 )]
 #[non_exhaustive]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum FrontMatterValue {
     /// A timestamp front matter value
     DateTime(FrontMatterDateTimeValue),

--- a/fiberplane-models/src/notebooks/front_matter.rs
+++ b/fiberplane-models/src/notebooks/front_matter.rs
@@ -81,6 +81,10 @@ pub enum FrontMatterValue {
     /// A PagerDuty incident front matter value
     #[serde(rename = "pagerduty_incident")]
     PagerDutyIncident(FrontMatterPagerDutyIncident),
+
+    /// A GitHub pull request front matter value
+    #[serde(rename = "github_pull_request")]
+    GitHubPullRequest(FrontMatterGitHubPullRequest),
 }
 
 /// Error from validating a JSON object as a correct front matter value
@@ -141,6 +145,7 @@ impl FrontMatterValue {
             FrontMatterValue::User(_) => "user",
             FrontMatterValue::UserList(_) => "user_list",
             FrontMatterValue::PagerDutyIncident(_) => "pagerduty_incident",
+            FrontMatterValue::GitHubPullRequest(_) => "github_pull_request",
         }
     }
 }
@@ -644,6 +649,73 @@ impl TryFrom<serde_json::Value> for FrontMatterPagerDutyIncident {
     fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
         serde_json::from_value(value).map_err(|err| FrontMatterValidationError::Format {
             message: format!("invalid pagerduty incident: {err}"),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, TypedBuilder)]
+#[cfg_attr(
+    feature = "fp-bindgen",
+    derive(Serializable),
+    fp(rust_module = "fiberplane_models::notebooks::front_matter")
+)]
+#[non_exhaustive]
+#[serde(rename_all = "camelCase")]
+pub struct FrontMatterGitHubPullRequest {
+    /// HTML url of this GitHub pull request. This is the only required value when creating
+    /// this front matter schema. Every other field is marked as optional and will be automatically
+    /// populated by the backend whenever front matter values get updated or an incoming GitHub
+    /// webhook got handled.
+    pub html_url: String,
+
+    /// Global unique ID of the GitHub pull request. This gets used to find this very front matter
+    /// within all notebooks whenever a webhook from GitHub gets handled. GitHub assigns this ID.
+    #[builder(setter())]
+    pub id: u64,
+
+    /// The owner of the repository where this pull request was created on
+    #[builder(setter(into))]
+    pub repo_owner: String,
+
+    /// The name of the repository where this pull request was created on
+    #[builder(setter(into))]
+    pub repo_name: String,
+
+    /// The pull request number within this repository. Please note that GitHub
+    /// treats pull request and issue numbers as the same.
+    #[builder(setter())]
+    pub number: u64,
+
+    /// Creator of the pull request
+    #[builder(setter(into))]
+    pub author: String,
+
+    /// Assignee of this pull request
+    #[builder(setter(into))]
+    pub assignee: String,
+
+    /// Current status of this pull request
+    #[builder(setter(into))]
+    pub status: String,
+
+    /// Timestamp of the last update received by Fiberplane to this pull request. May be outdated
+    /// if there are changes that the GitHub webhook has not yet sent out
+    #[builder(setter(into))]
+    pub last_updated: Timestamp,
+}
+
+impl From<FrontMatterGitHubPullRequest> for FrontMatterValue {
+    fn from(v: FrontMatterGitHubPullRequest) -> Self {
+        Self::GitHubPullRequest(v)
+    }
+}
+
+impl TryFrom<Value> for FrontMatterGitHubPullRequest {
+    type Error = FrontMatterValidationError;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        serde_json::from_value(value).map_err(|err| FrontMatterValidationError::Format {
+            message: format!("invalid github pull request: {err}"),
         })
     }
 }


### PR DESCRIPTION
# Description

not my best work but it needed to be done for the demo :) as this is for the demo please only block the merge if it legitimately would break dev, demo or prod.

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- [ ] The OpenAPI schema and generated client have been updated.
- [x] ~~New models module has been added to api generator xtask~~
- [x] ~~New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [ ] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
* Monofiber: https://github.com/fiberplane/monofiber/pull/366

After merging, please merge related PRs ASAP, so others don't get blocked.
