### PR TITLE
`@fiberplane/hooks`: Add `usePrevious` hook & fix side effect in `useThemeSelect`

### DIFF
--- a/fiberplane-hooks/package.json
+++ b/fiberplane-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiberplane/hooks",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Hooks for Fiberplane",
   "author": "Fiberplane <info@fiberplane.com>",
   "license": "MIT OR Apache-2.0",

--- a/fiberplane-hooks/src/index.ts
+++ b/fiberplane-hooks/src/index.ts
@@ -4,4 +4,5 @@ export * from "./useHandler";
 export * from "./useKeyPressEvent";
 export * from "./useLocalStorage";
 export * from "./useMedia";
+export * from "./usePrevious";
 export * from "./useThemeSelect";

--- a/fiberplane-hooks/src/usePrevious.ts
+++ b/fiberplane-hooks/src/usePrevious.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from "react";
+
+export function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T>();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}

--- a/fiberplane-hooks/src/useThemeSelect.ts
+++ b/fiberplane-hooks/src/useThemeSelect.ts
@@ -30,22 +30,21 @@ export function useThemeSelect() {
   const previousTheme = usePrevious(theme);
 
   useEffect(() => {
-    // Prevent setting the data attribute when the theme hasn't changed.
-    if (!previousTheme || previousTheme === theme) {
-      return;
-    }
-
-    // By setting `data-switching` we can apply a transition to the theme change
-    // in CSS.
-    document.body.dataset.switching = "true";
-    const listenerId = setTimeout(() => {
-      document.body.dataset.switching = "false";
-    }, 100);
-
     // Set the theme on the `document.body` element. If there's no stored theme,
     // we remove the `data-theme` attribute so the system's preferred color
     // scheme is used.
     document.body.dataset.theme = storedTheme ? theme : "";
+
+    let listenerId: ReturnType<typeof setTimeout>;
+
+    // By setting `data-switching` we can apply a transition to the theme change
+    // in CSS.
+    if (previousTheme && previousTheme !== theme) {
+      document.body.dataset.switching = "true";
+      listenerId = setTimeout(() => {
+        document.body.dataset.switching = "false";
+      }, 100);
+    }
 
     return () => {
       clearTimeout(listenerId);

--- a/fiberplane-hooks/src/useThemeSelect.ts
+++ b/fiberplane-hooks/src/useThemeSelect.ts
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
+
 import { useLocalStorage } from "./useLocalStorage";
 import { useMedia } from "./useMedia";
+import { usePrevious } from "./usePrevious";
 
 type Theme = "dark" | "light";
 
@@ -25,8 +27,14 @@ export function useThemeSelect() {
   // default theme.
   const theme: Theme =
     storedTheme && isValidTheme(storedTheme) ? storedTheme : systemDefaultTheme;
+  const previousTheme = usePrevious(theme);
 
   useEffect(() => {
+    // Prevent setting the data attribute when the theme hasn't changed.
+    if (!previousTheme || previousTheme === theme) {
+      return;
+    }
+
     // By setting `data-switching` we can apply a transition to the theme change
     // in CSS.
     document.body.dataset.switching = "true";


### PR DESCRIPTION
# Description

`useThemeSelect` had a side effect where the data attribute was set every time the hook got called, resulting in some UI bugs. This is fixed by adding a `usePrevious` hook that tracks the previous value!

When reviewed I'll bump the version & publish the package 🚀 