### PR TITLE
`@fiberplane/ui`: Button danger styles

### DIFF
--- a/fiberplane-charts/package.json
+++ b/fiberplane-charts/package.json
@@ -53,7 +53,7 @@
     "rollup": "^4.13.0",
     "rollup-plugin-dts": "^6.1.0",
     "rollup-plugin-swc3": "^0.11.0",
-    "styled-components": "^6.1.8",
+    "styled-components": "6.1.8",
     "typescript": "^5.4.2"
   },
   "scripts": {

--- a/fiberplane-hooks/src/useThemeSelect.ts
+++ b/fiberplane-hooks/src/useThemeSelect.ts
@@ -29,6 +29,8 @@ export function useThemeSelect() {
     storedTheme && isValidTheme(storedTheme) ? storedTheme : systemDefaultTheme;
   const previousTheme = usePrevious(theme);
 
+  /* biome-ignore lint/correctness/useExhaustiveDependencies: don't provide
+  `previousTheme` as a dependency */
   useEffect(() => {
     // Set the theme on the `document.body` element. If there's no stored theme,
     // we remove the `data-theme` attribute so the system's preferred color

--- a/fiberplane-ui/package.json
+++ b/fiberplane-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiberplane/ui",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "UI components for Fiberplane",
   "author": "Fiberplane <info@fiberplane.com>",
   "license": "MIT OR Apache-2.0",

--- a/fiberplane-ui/package.json
+++ b/fiberplane-ui/package.json
@@ -30,7 +30,7 @@
     "rollup-plugin-dts": "^6.1.0",
     "rollup-plugin-import-css": "^3.5.0",
     "rollup-plugin-swc3": "^0.11.0",
-    "styled-components": "^6.1.8",
+    "styled-components": "6.1.8",
     "tslib": "^2.6.2",
     "typescript": "^5.4.2"
   },

--- a/fiberplane-ui/src/components/Button.tsx
+++ b/fiberplane-ui/src/components/Button.tsx
@@ -175,6 +175,14 @@ function getButtonStyle(buttonStyle: ButtonStyle) {
         background-color: var(--color-bg-danger, #ffebf0);
         color: var(--color-fg-danger, #bf1b44);
         border: 1px solid var(--color-border-danger, #f53667);
+
+        &&:focus,
+        &&:focus-visible {
+          box-shadow: var(
+            --focus-error,
+            0px 0px 0px 4px rgb(245 54 103 / 20%)
+          );
+        }
       `;
     case "tertiary-color":
       return css`

--- a/fiberplane-ui/src/components/Button.tsx
+++ b/fiberplane-ui/src/components/Button.tsx
@@ -1,7 +1,12 @@
 import { forwardRef } from "react";
 import { css, styled } from "styled-components";
 
-type ButtonStyle = "primary" | "secondary" | "tertiary-color" | "tertiary-grey";
+export type ButtonStyle =
+  | "primary"
+  | "secondary"
+  | "tertiary-color"
+  | "tertiary-grey"
+  | "danger";
 
 export type ButtonStyleProps = {
   buttonStyle?: ButtonStyle;
@@ -165,6 +170,12 @@ function getButtonStyle(buttonStyle: ButtonStyle) {
           background-color: var(--color-button-secondary-bg, #fff);
           color: var(--color-fg-subtle, #bcb9bf);
         }
+      `;
+    case "danger":
+      return css`
+        min-height: 36px;
+        background-color: var(--color-bg-danger, #ffebf0);
+        color: var(--color-fg-danger-fg, #bf1b44);
       `;
     case "tertiary-color":
       return css`

--- a/fiberplane-ui/src/components/Button.tsx
+++ b/fiberplane-ui/src/components/Button.tsx
@@ -29,25 +29,23 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref,
   ) {
-    switch (buttonType) {
-      case "textButton":
-        return (
-          <StyledTextButton
-            ref={ref}
-            $buttonStyle={buttonStyle}
-            {...elementProps}
-          >
-            {children}
-          </StyledTextButton>
-        );
-
-      default:
-        return (
-          <StyledButton ref={ref} $buttonStyle={buttonStyle} {...elementProps}>
-            {children}
-          </StyledButton>
-        );
+    if (buttonType === "textButton") {
+      return (
+        <StyledTextButton
+          ref={ref}
+          $buttonStyle={buttonStyle}
+          {...elementProps}
+        >
+          {children}
+        </StyledTextButton>
+      );
     }
+
+    return (
+      <StyledButton ref={ref} $buttonStyle={buttonStyle} {...elementProps}>
+        {children}
+      </StyledButton>
+    );
   },
 );
 
@@ -175,7 +173,8 @@ function getButtonStyle(buttonStyle: ButtonStyle) {
       return css`
         min-height: 36px;
         background-color: var(--color-bg-danger, #ffebf0);
-        color: var(--color-fg-danger-fg, #bf1b44);
+        color: var(--color-fg-danger, #bf1b44);
+        border: 1px solid var(--color-border-danger, #f53667);
       `;
     case "tertiary-color":
       return css`

--- a/fiberplane-ui/src/components/Button.tsx
+++ b/fiberplane-ui/src/components/Button.tsx
@@ -1,14 +1,14 @@
 import { forwardRef } from "react";
 import { css, styled } from "styled-components";
 
-export type ButtonStyle =
+type ButtonStyle =
   | "primary"
   | "secondary"
   | "tertiary-color"
   | "tertiary-grey"
   | "danger";
 
-export type ButtonStyleProps = {
+type ButtonStyleProps = {
   buttonStyle?: ButtonStyle;
   buttonType?: "button" | "textButton";
 };


### PR DESCRIPTION
Adds a danger `buttonStyle`. Currently using some 'danger variables' used in other places, but does the job until new designs are available.

---

```tsx
<Button buttonStyle="danger">
  Muy peligroso!
</Button>
```
<img width="156" alt="Screenshot 2024-05-01 at 15 45 41" src="https://github.com/fiberplane/fiberplane/assets/33732524/d9fe3da1-6d03-4df3-ae9e-074cb681ed31">

---

Also locks `styled-components` to version `6.1.8` as the latest version introduces type issues.