### PR TITLE
Fix link to template docs when converting notebook to template

### DIFF
--- a/fiberplane-templates/src/convert/mod.rs
+++ b/fiberplane-templates/src/convert/mod.rs
@@ -166,7 +166,7 @@ pub fn cells_to_snippet(cells: &[Cell]) -> String {
 
 fn write_preamble(writer: &mut CodeWriter) {
     writer.println(
-        "// For documentation on Fiberplane Templates, see: https://docs.fiberplane.com/docs/templates",
+        "// For documentation on Fiberplane Templates, see: https://fiberplane.com/docs/templates",
     );
     writer.println(format!("local fp = import '{FIBERPLANE_LIBRARY_PATH}';"));
     writer.println("local c = fp.cell;");

--- a/fiberplane-templates/src/convert/mod.rs
+++ b/fiberplane-templates/src/convert/mod.rs
@@ -166,7 +166,7 @@ pub fn cells_to_snippet(cells: &[Cell]) -> String {
 
 fn write_preamble(writer: &mut CodeWriter) {
     writer.println(
-        "// For documentation on Fiberplane Templates, see: https://docs.fiberplane.com/templates",
+        "// For documentation on Fiberplane Templates, see: https://docs.fiberplane.com/docs/templates",
     );
     writer.println(format!("local fp = import '{FIBERPLANE_LIBRARY_PATH}';"));
     writer.println("local c = fp.cell;");


### PR DESCRIPTION
# Description

Right now when you convert a notebook to a template, the link to the templates documentation in the preamble at the top of the template is broken. This PR fixes the link

Fixes FP-3670

Related (but not dependent) PR: https://github.com/fiberplane/monofiber/pull/405
