### PR TITLE
allow changing display name for github pull requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ major version hasn't changed.
 - Add PagerDuty incident frontmatter object (#201)
 - Add `addFrontMatter` and `frontMatter.pagerdutyIncident` to `fiberplane.libsonnet` (#201)
 - `fiberplane-api-client`: New endpoint `integrations_github_app_pull_request_front_matter_add` has been added (#218)
-- `fiberplane-models`: New field `display_name` has been added to `GitHubAppAddPullRequest` (#218)
+- `fiberplane-models`: New fields `key` and `display_name` has been added to `GitHubAppAddPullRequest` (#218)
 
 ## [v1.0.0-beta.14] - 2024-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ major version hasn't changed.
 - Add models required for GitHub app workspace-level integration (#198)
 - Add PagerDuty incident frontmatter object (#201)
 - Add `addFrontMatter` and `frontMatter.pagerdutyIncident` to `fiberplane.libsonnet` (#201)
+- `fiberplane-api-client`: New endpoint `integrations_github_app_pull_request_front_matter_add` has been added (#218)
+- `fiberplane-models`: New field `display_name` has been added to `GitHubAppAddPullRequest` (#218)
 
 ## [v1.0.0-beta.14] - 2024-03-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ authors = ["Fiberplane <info@fiberplane.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fiberplane/fiberplane"
-rust-version = "1.64"
+rust-version = "1.70"
 
 [workspace.dependencies]
 base64uuid = { version = "1.1.0", path = "base64uuid", default-features = false }

--- a/fiberplane-api-client/src/lib.rs
+++ b/fiberplane-api-client/src/lib.rs
@@ -462,6 +462,23 @@ If you wish to delete a single key instead of the whole object, use the `patch` 
         Ok(response)
     }
 
+    #[doc = r#"Add a GitHub pull request to the notebooks front matter"#]
+    pub async fn integrations_github_app_pull_request_front_matter_add(
+        &self,
+        notebook_id: base64uuid::Base64Uuid,
+        payload: models::GitHubAppAddPullRequest,
+    ) -> Result<(), ApiClientError<models::GitHubAppAddPullRequestError>> {
+        let path = &format!(
+            "/api/notebooks/{notebookId}/integrations/github/pull_request",
+            notebookId = notebook_id,
+        );
+        let mut req = self.request(Method::POST, path)?;
+
+        let req = req.json(&payload);
+
+        self.do_req(req).await
+    }
+
     #[doc = r#"Convert the notebook cells to a snippet"#]
     pub async fn notebook_convert_to_snippet(
         &self,

--- a/fiberplane-models/src/integrations.rs
+++ b/fiberplane-models/src/integrations.rs
@@ -436,6 +436,9 @@ impl axum_07::response::IntoResponse for GitHubAppWebhookError {
 pub struct GitHubAppAddPullRequest {
     /// The url of the GitHub pull request
     pub url: String,
+
+    /// Display name of the front matter schema that should be displayed
+    pub display_name: Option<String>,
 }
 
 #[derive(Serialize, Debug, Error)]
@@ -448,13 +451,16 @@ pub enum GitHubAppAddPullRequestError {
     InvalidUrl,
 
     #[error("integration not installed")]
-    IntegrationNotInstalled,
+    NotInstalled,
 
     #[error("refresh token expired, please re-link integration")]
     RefreshTokenExpired,
 
     #[error("didnt receive new refresh token from GitHub")]
     RefreshTokenNotReceived,
+
+    #[error("this pull request was already linked")]
+    DuplicatePullRequest,
 
     #[error("unknown error occurred")]
     InternalServerError,
@@ -469,11 +475,10 @@ impl GitHubAppAddPullRequestError {
         match self {
             GitHubAppAddPullRequestError::AccessDenied => StatusCode::UNAUTHORIZED,
             GitHubAppAddPullRequestError::InvalidUrl => StatusCode::BAD_REQUEST,
-            GitHubAppAddPullRequestError::IntegrationNotInstalled => {
-                StatusCode::PRECONDITION_FAILED
-            }
+            GitHubAppAddPullRequestError::NotInstalled => StatusCode::PRECONDITION_FAILED,
             GitHubAppAddPullRequestError::RefreshTokenExpired => StatusCode::GONE,
             GitHubAppAddPullRequestError::RefreshTokenNotReceived => StatusCode::BAD_GATEWAY,
+            GitHubAppAddPullRequestError::DuplicatePullRequest => StatusCode::CONFLICT,
             GitHubAppAddPullRequestError::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
             GitHubAppAddPullRequestError::Auth(auth) => auth.status_code(),
         }

--- a/fiberplane-models/src/integrations.rs
+++ b/fiberplane-models/src/integrations.rs
@@ -349,7 +349,7 @@ impl axum_07::response::IntoResponse for GitHubAppUninstallError {
     }
 }
 
-#[derive(Serialize, Debug, Error)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Error)]
 #[serde(tag = "error", content = "details", rename_all = "snake_case")]
 pub enum GitHubAppWebhookError {
     #[error("signature was not sent with the request")]
@@ -444,7 +444,7 @@ pub struct GitHubAppAddPullRequest {
     pub display_name: Option<String>,
 }
 
-#[derive(Serialize, Debug, Error)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Error)]
 #[serde(tag = "error", content = "details", rename_all = "snake_case")]
 pub enum GitHubAppAddPullRequestError {
     #[error("access denied to repository")]

--- a/fiberplane-models/src/integrations.rs
+++ b/fiberplane-models/src/integrations.rs
@@ -435,9 +435,12 @@ impl axum_07::response::IntoResponse for GitHubAppWebhookError {
 #[serde(rename_all = "camelCase")]
 pub struct GitHubAppAddPullRequest {
     /// The url of the GitHub pull request
+    #[builder(setter(into))]
     pub url: String,
 
     /// Display name of the front matter schema that should be displayed
+    #[builder(default, setter(into))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
 }
 
@@ -459,8 +462,8 @@ pub enum GitHubAppAddPullRequestError {
     #[error("didnt receive new refresh token from GitHub")]
     RefreshTokenNotReceived,
 
-    #[error("this pull request was already linked")]
-    DuplicatePullRequest,
+    #[error("this issue or pull request was already linked")]
+    DuplicateResource,
 
     #[error("unknown error occurred")]
     InternalServerError,
@@ -478,7 +481,7 @@ impl GitHubAppAddPullRequestError {
             GitHubAppAddPullRequestError::NotInstalled => StatusCode::PRECONDITION_FAILED,
             GitHubAppAddPullRequestError::RefreshTokenExpired => StatusCode::GONE,
             GitHubAppAddPullRequestError::RefreshTokenNotReceived => StatusCode::BAD_GATEWAY,
-            GitHubAppAddPullRequestError::DuplicatePullRequest => StatusCode::CONFLICT,
+            GitHubAppAddPullRequestError::DuplicateResource => StatusCode::CONFLICT,
             GitHubAppAddPullRequestError::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
             GitHubAppAddPullRequestError::Auth(auth) => auth.status_code(),
         }

--- a/fiberplane-models/src/integrations.rs
+++ b/fiberplane-models/src/integrations.rs
@@ -438,7 +438,14 @@ pub struct GitHubAppAddPullRequest {
     #[builder(setter(into))]
     pub url: String,
 
-    /// Display name of the front matter schema that should be displayed
+    /// Key which will be used to internally refer to this GitHub pull request front matter.
+    /// If not specified, falls back to `github_pull_request_<id>`
+    #[builder(default, setter(into))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+
+    /// Display name of the front matter schema that should be displayed.
+    /// If not specified, falls back to `GitHub pull request`
     #[builder(default, setter(into))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2775,7 +2775,80 @@ components:
           unauthorized: "#/components/schemas/unauthorizedError"
           unauthenticated: "#/components/schemas/unauthenticatedError"
           not_installed: "#/components/schemas/gitHubAppNotInstalledError"
-
+    gitHubAppAddPullRequest:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
+          description: URL of the GitHub pull request
+        display_name:
+          type: string
+          description: Display name of the Front Matter schema
+    gitHubAppAddPullRequestError:
+      oneOf:
+        - $ref: "#/components/schemas/internalServerError"
+        - $ref: "#/components/schemas/unauthorizedError"
+        - $ref: "#/components/schemas/unauthenticatedError"
+        - $ref: "#/components/schemas/gitHubAppNotInstalledError"
+      discriminator:
+        propertyName: error
+        mapping:
+          access_denied: "#/components/schemas/gitHubAppAccessDenied"
+          invalid_url: "#/components/schemas/gitHubAppInvalidUrl"
+          not_installed: "#/components/schemas/gitHubAppNotInstalledError"
+          refresh_token_expired: "#/components/schemas/gitHubAppRefreshTokenExpired"
+          refresh_token_not_received: "#/components/schemas/gitHubAppRefreshTokenNotReceived"
+          duplicate_pull_request: "#/components/schemas/gitHubAppDuplicatePullRequest"
+          internal_server_error: "#/components/schemas/internalServerError"
+          unauthorized: "#/components/schemas/unauthorizedError"
+          unauthenticated: "#/components/schemas/unauthenticatedError"
+    gitHubAppAccessDenied:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - "access_denied"
+    gitHubAppInvalidUrl:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - "invalid_url"
+    gitHubAppRefreshTokenExpired:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - "refresh_token_expired"
+    gitHubAppRefreshTokenNotReceived:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - "refresh_token_not_received"
+    gitHubAppDuplicatePullRequest:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          enum:
+            - "duplicate_pull_request"
   parameters:
     sortDirection:
       in: query
@@ -3271,6 +3344,32 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/threadSummary"
+  /api/notebooks/{notebookId}/integrations/github/pull_request:
+    parameters:
+      - $ref: "#/components/parameters/notebookId"
+    post:
+      operationId: integrations_github_app_pull_request_front_matter_add
+      summary: Add a GitHub pull request to the notebooks front matter
+      description: Add a GitHub pull request to the notebooks front matter
+      x-new-style: true
+      tags:
+        - Notebooks
+        - Front Matter Schema
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/gitHubAppAddPullRequest"
+      responses:
+        "200":
+          description: OK
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/gitHubAppAddPullRequestError"
   /api/notebooks/{notebookId}/front_matter:
     parameters:
       - $ref: "#/components/parameters/notebookId"

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2783,6 +2783,9 @@ components:
         url:
           type: string
           description: URL of the GitHub pull request
+        key:
+          type: string
+          description: Key which will be used to internally refer to this GitHub pull request front matter
         display_name:
           type: string
           description: Display name of the Front Matter schema

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2800,7 +2800,7 @@ components:
           not_installed: "#/components/schemas/gitHubAppNotInstalledError"
           refresh_token_expired: "#/components/schemas/gitHubAppRefreshTokenExpired"
           refresh_token_not_received: "#/components/schemas/gitHubAppRefreshTokenNotReceived"
-          duplicate_pull_request: "#/components/schemas/gitHubAppDuplicatePullRequest"
+          duplicate_pull_request: "#/components/schemas/gitHubAppDuplicateResource"
           internal_server_error: "#/components/schemas/internalServerError"
           unauthorized: "#/components/schemas/unauthorizedError"
           unauthenticated: "#/components/schemas/unauthenticatedError"
@@ -2840,7 +2840,7 @@ components:
           type: string
           enum:
             - "refresh_token_not_received"
-    gitHubAppDuplicatePullRequest:
+    gitHubAppDuplicateResource:
       type: object
       required:
         - error
@@ -2848,7 +2848,7 @@ components:
         error:
           type: string
           enum:
-            - "duplicate_pull_request"
+            - "duplicate_resource"
   parameters:
     sortDirection:
       in: query


### PR DESCRIPTION
# Description

with the introduction of lookup tables, the display name of github pull requests can now be changed

Fixes FP-3672

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] ~~The changes have been tested to be backwards compatible.~~ theyre not
- [x] The OpenAPI schema and generated client have been updated.
- [x] ~~New models module has been added to api generator xtask~~
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
* Monofiber: https://github.com/fiberplane/monofiber/pull/407

After merging, please merge related PRs ASAP, so others don't get blocked.
