### PR TITLE
models(pagerduty): Use arrays for teams and assignees

### DIFF
--- a/fiberplane-models/src/notebooks/front_matter.rs
+++ b/fiberplane-models/src/notebooks/front_matter.rs
@@ -669,10 +669,10 @@ pub struct FrontMatterPagerDutyIncident {
     pub resolve_reason: Option<String>,
 
     #[builder(default, setter(into))]
-    pub assignees: Option<String>,
+    pub assignees: Vec<String>,
 
     #[builder(default, setter(into))]
-    pub teams: Option<String>,
+    pub teams: Vec<String>,
 }
 
 impl From<FrontMatterPagerDutyIncident> for FrontMatterValue {


### PR DESCRIPTION
# Description

Change the models for the PagerDuty content to fit better
the reality of assignees and teams

Fixes half of FP-3658

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [ ] The changes have been tested to be backwards compatible.
- [ ] The OpenAPI schema and generated client have been updated.
- [x] New models module has been added to api generator xtask
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [ ] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

* Monofiber: https://github.com/fiberplane/monofiber/pull/

After merging, please merge related PRs ASAP, so others don't get blocked.
