### PR TITLE
add soft redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ major version hasn't changed.
 - Add `addFrontMatter` and `frontMatter.pagerdutyIncident` to `fiberplane.libsonnet` (#201)
 - `fiberplane-api-client`: New endpoint `integrations_github_app_pull_request_front_matter_add` has been added (#218)
 - `fiberplane-models`: New fields `key` and `display_name` has been added to `GitHubAppAddPullRequest` (#218)
+- `fiberplane-models`: Rename `OidLinkupLocation` to `SoftRedirect` (#224)
 
 ## [v1.0.0-beta.14] - 2024-03-07
 

--- a/fiberplane-api-client/Cargo.toml
+++ b/fiberplane-api-client/Cargo.toml
@@ -37,7 +37,7 @@ description = "Generated API client for Fiberplane API"
 edition = "2021"
 name = "fiberplane-api-client"
 readme = "README.md"
-rust-version = "1.64"
+rust-version = "1.70"
 
 [package.license]
 workspace = true

--- a/fiberplane-api-client/src/lib.rs
+++ b/fiberplane-api-client/src/lib.rs
@@ -587,7 +587,7 @@ For authenticating with the API see the Authentication section in the docs
         provider: &str,
         cli_redirect_port: Option<i32>,
         redirect: Option<&str>,
-    ) -> Result<models::OidLinkupLocation> {
+    ) -> Result<models::SoftRedirect> {
         let mut builder = self.request(
             Method::POST,
             &format!("/api/oidc/linkup/{provider}", provider = provider,),
@@ -1147,7 +1147,7 @@ For authenticating with the API see the Authentication section in the docs
     pub async fn integrations_github_app_install(
         &self,
         workspace_id: base64uuid::Base64Uuid,
-    ) -> Result<(), ApiClientError<models::GitHubAppInstallFlowError>> {
+    ) -> Result<models::SoftRedirect, ApiClientError<models::GitHubAppInstallFlowError>> {
         let path = &format!(
             "/api/workspaces/{workspaceId}/integrations/github/install",
             workspaceId = workspace_id,
@@ -1161,7 +1161,7 @@ For authenticating with the API see the Authentication section in the docs
     pub async fn integrations_github_app_uninstall(
         &self,
         workspace_id: base64uuid::Base64Uuid,
-    ) -> Result<(), ApiClientError<models::GitHubAppUninstallError>> {
+    ) -> Result<models::SoftRedirect, ApiClientError<models::GitHubAppUninstallError>> {
         let path = &format!(
             "/api/workspaces/{workspaceId}/integrations/github/uninstall",
             workspaceId = workspace_id,

--- a/fiberplane-models/src/users.rs
+++ b/fiberplane-models/src/users.rs
@@ -69,7 +69,7 @@ pub struct OidConnection {
 )]
 #[non_exhaustive]
 #[serde(rename_all = "camelCase")]
-pub struct OidLinkupLocation {
+pub struct SoftRedirect {
     #[builder(setter(into))]
     pub location: String,
 }

--- a/schemas/openapi_v1.yml
+++ b/schemas/openapi_v1.yml
@@ -2416,7 +2416,7 @@ components:
             - github
         linked:
           type: boolean
-    oidLinkupLocation:
+    softRedirect:
       type: object
       required:
         - location
@@ -3997,7 +3997,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/oidLinkupLocation"
+                $ref: "#/components/schemas/softRedirect"
   /api/logout:
     post:
       operationId: logout
@@ -5519,8 +5519,12 @@ paths:
       tags:
         - Integrations
       responses:
-        "307":
-          description: OK. Follow Location header
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/softRedirect"
         default:
           description: Error
           content:
@@ -5538,8 +5542,12 @@ paths:
       tags:
         - Integrations
       responses:
-        "307":
-          description: OK. Follow Location header
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/softRedirect"
         default:
           description: Error
           content:


### PR DESCRIPTION
# Description

as requested by frontendeers to prevent `fetch` related weirdness

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- [x] The OpenAPI schema and generated client have been updated.
- [x] ~~New models module has been added to api generator xtask~~
- [x] ~~New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
* Monofiber: https://github.com/fiberplane/monofiber/pull/417

After merging, please merge related PRs ASAP, so others don't get blocked.
