### PR TITLE
replace pagerduty panics with actual errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ major version hasn't changed.
 - `fiberplane-api-client`: New endpoint `integrations_github_app_pull_request_front_matter_add` has been added (#218)
 - `fiberplane-models`: New fields `key` and `display_name` has been added to `GitHubAppAddPullRequest` (#218)
 - `fiberplane-models`: Rename `OidLinkupLocation` to `SoftRedirect` (#224)
+- `fiberplane-models`: New variants have been added to `PagerDutyReceiverWebhookError` (#226)
 
 ## [v1.0.0-beta.14] - 2024-03-07
 

--- a/fiberplane-models/src/pagerduty.rs
+++ b/fiberplane-models/src/pagerduty.rs
@@ -443,6 +443,7 @@ impl PagerDutyReceiverWebhookError {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             PagerDutyReceiverWebhookError::SerializationFailed => StatusCode::INTERNAL_SERVER_ERROR,
+            PagerDutyReceiverWebhookError::UnsupportedEvent => StatusCode::NOT_IMPLEMENTED,
         }
     }
 }

--- a/fiberplane-models/src/pagerduty.rs
+++ b/fiberplane-models/src/pagerduty.rs
@@ -395,6 +395,30 @@ impl SortField for PagerDutyReceiverListSortFields {
 #[non_exhaustive]
 #[serde(tag = "error", rename_all = "snake_case")]
 pub enum PagerDutyReceiverWebhookError {
+    #[error("this event is unsupported")]
+    UnsupportedEvent,
+
+    #[error("already exists")]
+    Duplicate,
+
+    #[error("expected front matter to be of type `PagerDutyIncident` but it was not")]
+    UnexpectedFrontMatterType,
+
+    #[error("incident in front matter does not match the received incident from the webhook")]
+    MismatchingIncident,
+
+    #[error("failed to parse payload as JSON")]
+    InvalidJson,
+
+    #[error("template not found")]
+    TemplateNotFound,
+
+    #[error("failed to expand template")]
+    TemplateExpansionFailed,
+
+    #[error("failed to serialize into json")]
+    SerializationFailed,
+
     #[error("Unknown error occurred")]
     InternalServerError,
 
@@ -408,6 +432,17 @@ impl PagerDutyReceiverWebhookError {
         match self {
             PagerDutyReceiverWebhookError::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
             PagerDutyReceiverWebhookError::InvalidSignature => StatusCode::BAD_REQUEST,
+            PagerDutyReceiverWebhookError::Duplicate => StatusCode::CONFLICT,
+            PagerDutyReceiverWebhookError::UnexpectedFrontMatterType => {
+                StatusCode::PRECONDITION_FAILED
+            }
+            PagerDutyReceiverWebhookError::MismatchingIncident => StatusCode::BAD_REQUEST,
+            PagerDutyReceiverWebhookError::InvalidJson => StatusCode::BAD_REQUEST,
+            PagerDutyReceiverWebhookError::TemplateNotFound => StatusCode::NOT_FOUND,
+            PagerDutyReceiverWebhookError::TemplateExpansionFailed => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            PagerDutyReceiverWebhookError::SerializationFailed => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/fiberplane-models/src/pagerduty.rs
+++ b/fiberplane-models/src/pagerduty.rs
@@ -416,9 +416,6 @@ pub enum PagerDutyReceiverWebhookError {
     #[error("failed to expand template")]
     TemplateExpansionFailed,
 
-    #[error("failed to serialize into json")]
-    SerializationFailed,
-
     #[error("Unknown error occurred")]
     InternalServerError,
 
@@ -442,7 +439,6 @@ impl PagerDutyReceiverWebhookError {
             PagerDutyReceiverWebhookError::TemplateExpansionFailed => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
-            PagerDutyReceiverWebhookError::SerializationFailed => StatusCode::INTERNAL_SERVER_ERROR,
             PagerDutyReceiverWebhookError::UnsupportedEvent => StatusCode::NOT_IMPLEMENTED,
         }
     }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context.

fixes FP-3660

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- [x] ~~The OpenAPI schema and generated client have been updated.~~
- [x] ~~New models module has been added to api generator xtask~~
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
* Monofiber: https://github.com/fiberplane/monofiber/pull/420

After merging, please merge related PRs ASAP, so others don't get blocked.
