### PR TITLE
Add support for creating provider cell in markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,12 @@ major version hasn't changed.
 
 - `fiberplane-markdown`: markdown to notebook behavior updated: 
   - store syntax/language if specified in code
-  - added support for prometheus provider cells using a special code   syntax:
-    ```
-      ``` promql
-      # fiberplane-provider-query
-      node_network_transmit_bytes_total[30s]
-      ```
-    ```
+  - added support for prometheus provider cells using a special syntax. First start by specifying the language as promql and start the content with `# fiberplane-provider-query`. So the first part should look like:
+  ``` md
+    ``` promql
+    # fiberplane-provider-query
+  ```
+  The rest of the code block is assumed to be the query  
 - `fiberplane-ui`: Fix input border colors in dark mode (use `--color-input-border-default` instead of `--color-input-border`)
 - `fiberplane-charts`: Add configuration to MetricsChart for number of ticks you'd prefer to see on an axis (defaults to previously hard-coded values)
 - `fiberplane-models`: Add extra types to front matter values, and add a value validation method to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ major version hasn't changed.
 
 ## unreleased
 
+- `fiberplane-markdown`: markdown to notebook behavior updated: 
+  - store syntax/language if specified in code
+  - added support for prometheus provider cells using a special code   syntax:
+    ```
+      ``` promql
+      # fiberplane-provider-query
+      node_network_transmit_bytes_total[30s]
+      ```
+    ```
 - `fiberplane-ui`: Fix input border colors in dark mode (use `--color-input-border-default` instead of `--color-input-border`)
 - `fiberplane-charts`: Add configuration to MetricsChart for number of ticks you'd prefer to see on an axis (defaults to previously hard-coded values)
 - `fiberplane-models`: Add extra types to front matter values, and add a value validation method to

--- a/fiberplane-markdown/src/from_markdown/mod.rs
+++ b/fiberplane-markdown/src/from_markdown/mod.rs
@@ -123,8 +123,7 @@ impl<'a> MarkdownConverter<'a> {
                             cell_text.push_str(&content);
                             continue;
                         }
-                    } else if self.current_code_block_syntax.is_some() {
-                        let syntax = self.current_code_block_syntax.take().unwrap();
+                    } else if let Some(syntax) = self.current_code_block_syntax {
 
                         // Check for magic string that indicates a query/provider cell
                         if content

--- a/fiberplane-markdown/src/from_markdown/mod.rs
+++ b/fiberplane-markdown/src/from_markdown/mod.rs
@@ -14,6 +14,7 @@ use tracing::warn;
 #[cfg(test)]
 mod tests;
 
+const PROVIDER_CELL_DIRECTIVE: &str = "# fiberplane-provider-query\n";
 /// Convert Markdown to a Fiberplane notebook
 ///
 /// This parses the first heading as the notebook title and
@@ -125,13 +126,11 @@ impl<'a> MarkdownConverter<'a> {
                         }
                     } else if let Some(ref syntax) = self.current_code_block_syntax {
                         // Check for magic string that indicates a query/provider cell
-                        if content
-                            .trim_start()
-                            .starts_with("# fiberplane-provider-query\n")
+                        if content.trim_start().starts_with(PROVIDER_CELL_DIRECTIVE)
                             && syntax.to_lowercase() == "promql"
                         {
                             let query = content
-                                .strip_prefix("# fiberplane-provider-query\n")
+                                .strip_prefix(PROVIDER_CELL_DIRECTIVE)
                                 .unwrap()
                                 .strip_suffix('\n')
                                 .unwrap();

--- a/fiberplane-markdown/src/from_markdown/mod.rs
+++ b/fiberplane-markdown/src/from_markdown/mod.rs
@@ -123,8 +123,7 @@ impl<'a> MarkdownConverter<'a> {
                             cell_text.push_str(&content);
                             continue;
                         }
-                    } else if let Some(syntax) = self.current_code_block_syntax {
-
+                    } else if let Some(ref syntax) = self.current_code_block_syntax {
                         // Check for magic string that indicates a query/provider cell
                         if content
                             .trim_start()
@@ -134,13 +133,13 @@ impl<'a> MarkdownConverter<'a> {
                             let query = content
                                 .strip_prefix("# fiberplane-provider-query\n")
                                 .unwrap()
-                                .strip_suffix("\n")
+                                .strip_suffix('\n')
                                 .unwrap();
 
                             let query_data = set_query_field(
                                 "application/x-www-form-urlencoded",
                                 "query",
-                                query.to_string(),
+                                query,
                             );
 
                             let cell = Cell::Provider(
@@ -153,17 +152,19 @@ impl<'a> MarkdownConverter<'a> {
                             self.new_cell(cell);
                         } else {
                             // Build a code cell with content and syntax unless syntax is an empty string
-                            let code_cell = if syntax.len() > 0 {
-                                CodeCell::builder()
-                                    .content(content.to_string())
-                                    .syntax(syntax.as_str())
-                                    .build()
+                            let cell = if !syntax.is_empty() {
+                                Cell::Code(
+                                    CodeCell::builder()
+                                        .content(content.to_string())
+                                        .syntax(syntax.as_str())
+                                        .build(),
+                                )
                             } else {
-                                CodeCell::builder().content(content.to_string()).build()
+                                Cell::Code(CodeCell::builder().content(content.to_string()).build())
                             };
 
                             // Create a Code cell
-                            self.new_cell(Cell::Code(code_cell));
+                            self.new_cell(cell);
                         }
                         self.current_code_block_syntax = None;
                     } else {

--- a/fiberplane-markdown/src/from_markdown/mod.rs
+++ b/fiberplane-markdown/src/from_markdown/mod.rs
@@ -130,6 +130,7 @@ impl<'a> MarkdownConverter<'a> {
                         if content
                             .trim_start()
                             .starts_with("# fiberplane-provider-query\n")
+                            && syntax.to_lowercase() == "promql"
                         {
                             let query = content
                                 .strip_prefix("# fiberplane-provider-query\n")

--- a/fiberplane-markdown/src/from_markdown/mod.rs
+++ b/fiberplane-markdown/src/from_markdown/mod.rs
@@ -1,11 +1,14 @@
 use fiberplane_models::formatting::{Annotation, AnnotationWithOffset};
 use fiberplane_models::notebooks::{
     Cell, CheckboxCell, CodeCell, DividerCell, HeadingCell, HeadingType, ImageCell, ListItemCell,
-    ListType, NewNotebook, TextCell,
+    ListType, NewNotebook, ProviderCell, TextCell,
 };
+use fiberplane_models::query_data::set_query_field;
 use fiberplane_models::timestamps::{NewTimeRange, RelativeTimeRange};
 use fiberplane_models::utils::char_count;
-use pulldown_cmark::{CowStr, Event::*, HeadingLevel, LinkType, Options, Parser, Tag};
+use pulldown_cmark::{
+    CodeBlockKind, CowStr, Event::*, HeadingLevel, LinkType, Options, Parser, Tag,
+};
 use tracing::warn;
 
 #[cfg(test)]
@@ -39,6 +42,7 @@ struct MarkdownConverter<'a> {
     cells: Vec<Cell>,
     /// If the title is the only H1 in the document, we will decrement the level of all other headings
     decrement_heading_level: bool,
+    current_code_block_syntax: Option<String>,
 }
 
 impl<'a> MarkdownConverter<'a> {
@@ -52,6 +56,7 @@ impl<'a> MarkdownConverter<'a> {
             current_cell: None,
             lists: Vec::new(),
             cells: Vec::new(),
+            current_code_block_syntax: None,
             decrement_heading_level: false,
         }
     }
@@ -118,8 +123,52 @@ impl<'a> MarkdownConverter<'a> {
                             cell_text.push_str(&content);
                             continue;
                         }
+                    } else if self.current_code_block_syntax.is_some() {
+                        let syntax = self.current_code_block_syntax.take().unwrap();
+
+                        // Check for magic string that indicates a query/provider cell
+                        if content
+                            .trim_start()
+                            .starts_with("# fiberplane-provider-query\n")
+                        {
+                            let query = content
+                                .strip_prefix("# fiberplane-provider-query\n")
+                                .unwrap()
+                                .strip_suffix("\n")
+                                .unwrap();
+
+                            let query_data = set_query_field(
+                                "application/x-www-form-urlencoded",
+                                "query",
+                                query.to_string(),
+                            );
+
+                            let cell = Cell::Provider(
+                                ProviderCell::builder()
+                                    .intent("prometheus,timeseries")
+                                    .query_data(query_data)
+                                    .build(),
+                            );
+
+                            self.new_cell(cell);
+                        } else {
+                            // Build a code cell with content and syntax unless syntax is an empty string
+                            let code_cell = if syntax.len() > 0 {
+                                CodeCell::builder()
+                                    .content(content.to_string())
+                                    .syntax(syntax.as_str())
+                                    .build()
+                            } else {
+                                CodeCell::builder().content(content.to_string()).build()
+                            };
+
+                            // Create a Code cell
+                            self.new_cell(Cell::Code(code_cell));
+                        }
+                        self.current_code_block_syntax = None;
+                    } else {
+                        self.new_text_cell(content.to_string());
                     }
-                    self.new_text_cell(content.to_string());
                 }
                 // Inline code
                 Code(content) => {
@@ -226,8 +275,18 @@ impl<'a> MarkdownConverter<'a> {
                 // We don't yet support block quotes so we'll just treat them as text cells
                 self.new_text_cell(String::new());
             }
-            Tag::CodeBlock(_) => {
-                self.new_cell(Cell::Code(CodeCell::default()));
+            Tag::CodeBlock(kind) => {
+                match kind {
+                    CodeBlockKind::Fenced(language) => {
+                        self.current_code_block_syntax = Some(language.to_string());
+                    }
+                    CodeBlockKind::Indented => {
+                        self.current_code_block_syntax = Some("".to_string());
+                    }
+                }
+                // self.current_code_block_syntax = Some(kind.as_str());
+                self.current_cell = None;
+                // self.new_cell(Cell::Code(CodeCell::default()));
             }
             Tag::List(start_number) => {
                 let (start_number, list_type) = if let Some(start_number) = start_number {
@@ -310,6 +369,7 @@ impl<'a> MarkdownConverter<'a> {
                 }
             }
             Tag::CodeBlock(_) => {
+                // self.in_code_block = false;
                 if let Some(mut cell) = self.current_cell.take() {
                     if let Cell::Code(cell) = &mut cell {
                         // Code blocks keep the newline that separates the content from the final ```,

--- a/fiberplane-markdown/src/from_markdown/mod.rs
+++ b/fiberplane-markdown/src/from_markdown/mod.rs
@@ -285,9 +285,7 @@ impl<'a> MarkdownConverter<'a> {
                         self.current_code_block_syntax = Some("".to_string());
                     }
                 }
-                // self.current_code_block_syntax = Some(kind.as_str());
                 self.current_cell = None;
-                // self.new_cell(Cell::Code(CodeCell::default()));
             }
             Tag::List(start_number) => {
                 let (start_number, list_type) = if let Some(start_number) = start_number {
@@ -370,7 +368,6 @@ impl<'a> MarkdownConverter<'a> {
                 }
             }
             Tag::CodeBlock(_) => {
-                // self.in_code_block = false;
                 if let Some(mut cell) = self.current_cell.take() {
                     if let Cell::Code(cell) = &mut cell {
                         // Code blocks keep the newline that separates the content from the final ```,

--- a/fiberplane-markdown/src/from_markdown/tests.rs
+++ b/fiberplane-markdown/src/from_markdown/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use fiberplane_models::notebooks::CodeCell;
+use fiberplane_models::{notebooks::CodeCell, query_data::get_query_field};
 use test_case::test_case;
 
 #[test_case("# Title\nContent", "Title"; "h1")]
@@ -118,7 +118,7 @@ fn parsing_rich_text() {
 fn parsing_code_blocks() {
     let cells = markdown_to_cells(
         "
-```
+``` bash
 Some code
 ```
 
@@ -128,6 +128,11 @@ on multiple lines
 ```",
     );
     assert_eq!(cells[0].content(), Some("Some code"));
+    if let Cell::Code(cell) = &cells[0] {
+        assert_eq!(cell.syntax, Some("bash".to_string()));
+    } else {
+        panic!("expected code cell");
+    }
     assert!(matches!(cells[0], Cell::Code(_)));
     assert_eq!(
         cells[1].content(),
@@ -333,4 +338,25 @@ fn html_goes_into_code_cell() {
     assert_eq!(cells[0].content(), Some("<p>a</p>\n"));
     assert!(matches!(cells[1], Cell::Code(CodeCell { .. })));
     assert_eq!(cells[1].content(), Some("<p>b</p><div>hello</div>"));
+}
+
+#[test]
+fn parsing_prometheus_provider_cell() {
+    let markdown =
+        "``` promql\n# fiberplane-provider-query\nnode_scrape_collector_duration_seconds\n```\n";
+    let cells = markdown_to_cells(markdown);
+    assert_eq!(cells.len(), 1);
+    if let Cell::Provider(cell) = &cells[0] {
+        assert!(cell.intent.contains("prometheus"));
+        if let Some(query_data) = &cell.query_data {
+            assert_eq!(
+                get_query_field(query_data.as_str(), "query"),
+                "node_scrape_collector_duration_seconds"
+            );
+        } else {
+            panic!("expected query data");
+        }
+    } else {
+        panic!("expected prometheus provider cell");
+    }
 }


### PR DESCRIPTION
# Description

Adding something like:

```
  ``` promql
  # fiberplane-provider-query
```

Will now result in a provider cell with the query parameter set to `node_network_transmit_bytes_total[30s]`

Also:

The syntax that is specified in the markdown is now passed to the code cell


Fixes FP-3734 

- [x] The changes have been tested to be backwards compatible.
- [ ]  ~~The OpenAPI schema and generated client have been updated~~
- [ ]  ~~New models module has been added to api generator xtask~~
- [ ]  ~~New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).~~
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
