### PR TITLE
Add new annotation type for notebook links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ major version hasn't changed.
 - `fiberplane-charts`: Updated `framer-motion` from `^10.18.0` to `^11.2.3`
 - `fiberplane-templates`: Add jsonnet helpers to create front matter schema's and values: `frontMatter.number`, `frontMatter.string`, `frontMatter.dateTime` and `frontMatter.user`
 - `fiberplane-templates`: Update `addFrontMatter` to handle arrays of values
+- `fiberplane-models`: Add annotation type for notebook links
 
 ## [v1.0.0-beta.14] - 2024-03-07
 

--- a/fiberplane-models/src/formatting.rs
+++ b/fiberplane-models/src/formatting.rs
@@ -93,15 +93,16 @@ pub enum Annotation {
     EndHighlight,
     StartItalics,
     EndItalics,
-    Label(Label),
-    StartLink { url: String },
-    EndLink,
-    Mention(Mention),
     StartStrikethrough,
     EndStrikethrough,
-    Timestamp { timestamp: Timestamp },
     StartUnderline,
     EndUnderline,
+    StartLink { url: String },
+    EndLink,
+    Label(Label),
+    Mention(Mention),
+    NotebookLink { url: String },
+    Timestamp { timestamp: Timestamp },
 }
 
 impl Annotation {
@@ -128,15 +129,16 @@ impl Annotation {
             Annotation::EndHighlight => Some(Annotation::StartHighlight),
             Annotation::StartItalics => Some(Annotation::EndItalics),
             Annotation::EndItalics => Some(Annotation::StartItalics),
-            Annotation::StartLink { .. } => Some(Annotation::EndLink),
-            Annotation::EndLink => None,
-            Annotation::Mention(_) => None,
-            Annotation::Timestamp { .. } => None,
             Annotation::StartStrikethrough => Some(Annotation::EndStrikethrough),
             Annotation::EndStrikethrough => Some(Annotation::StartStrikethrough),
             Annotation::StartUnderline => Some(Annotation::EndUnderline),
             Annotation::EndUnderline => Some(Annotation::StartUnderline),
+            Annotation::StartLink { .. } => Some(Annotation::EndLink),
+            Annotation::EndLink => None,
             Annotation::Label(_) => None,
+            Annotation::Mention(_) => None,
+            Annotation::NotebookLink { .. } => None,
+            Annotation::Timestamp { .. } => None,
         }
     }
 }
@@ -156,14 +158,16 @@ pub struct ActiveFormatting {
     pub code: bool,
     pub highlight: bool,
     pub italics: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub link: Option<String>,
     pub strikethrough: bool,
     pub underline: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub link: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<Label>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mention: Option<Mention>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notebook_link: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<Timestamp>,
 }
@@ -221,6 +225,13 @@ impl ActiveFormatting {
     pub fn with_label(&self, label: impl Into<Option<Label>>) -> Self {
         Self {
             label: label.into(),
+            ..self.clone()
+        }
+    }
+
+    pub fn with_notebook_link(&self, notebook_link: impl Into<Option<String>>) -> Self {
+        Self {
+            notebook_link: notebook_link.into(),
             ..self.clone()
         }
     }
@@ -295,6 +306,11 @@ impl ActiveFormatting {
                 annotations.push(Annotation::Mention(mention.clone()))
             }
         }
+        if self.notebook_link != reference.notebook_link {
+            if let Some(url) = self.notebook_link.as_ref() {
+                annotations.push(Annotation::NotebookLink { url: url.clone() })
+            }
+        }
         if self.timestamp != reference.timestamp {
             if let Some(timestamp) = self.timestamp {
                 annotations.push(Annotation::Timestamp { timestamp })
@@ -314,15 +330,16 @@ impl ActiveFormatting {
             Annotation::EndHighlight => !self.highlight,
             Annotation::StartItalics => self.italics,
             Annotation::EndItalics => !self.italics,
-            Annotation::StartLink { .. } => self.link.is_some(),
-            Annotation::EndLink => self.link.is_none(),
-            Annotation::Mention(_) => self.mention.is_some(),
-            Annotation::Timestamp { .. } => self.timestamp.is_some(),
             Annotation::StartStrikethrough => self.strikethrough,
             Annotation::EndStrikethrough => !self.strikethrough,
             Annotation::StartUnderline => self.underline,
             Annotation::EndUnderline => !self.underline,
+            Annotation::StartLink { .. } => self.link.is_some(),
+            Annotation::EndLink => self.link.is_none(),
             Annotation::Label(_) => self.label.is_some(),
+            Annotation::Mention(_) => self.mention.is_some(),
+            Annotation::NotebookLink { .. } => self.link.is_some(),
+            Annotation::Timestamp { .. } => self.timestamp.is_some(),
         }
     }
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context.

Implements [FP-3666](https://linear.app/fiberplane/issue/FP-3666/stylized-links-to-other-notebooks)

# Checklist

<!--
Please make sure all of these are checked before merging. Please leave items
you think are non-applicable in the list, but use strike-through (`~~`) to
indicate they don't apply.
-->

- [x] The changes have been tested to be backwards compatible.
- [ ] The OpenAPI schema and generated client have been updated.
- [ ] New models module has been added to api generator xtask
- [x] New types/fields are [well-documented and annotated](/CONTRIBUTING.md#adding-types-and-their-annotations).
- [x] The CHANGELOG is updated.

> Please link any related PRs in other repositories that depend on this:

<!-- * Providers: https://github.com/fiberplane/providers/pull/XXX -->
<!-- * Daemon: https://github.com/fiberplane/fpd/pull/XXX -->
<!-- * FP: https://github.com/fiberplane/fp/pull/XXX -->
<!-- * Monofiber: https://github.com/fiberplane/monofiber/pull/XXX -->

After merging, please merge related PRs ASAP, so others don't get blocked.
